### PR TITLE
Ceramic-One Instruction Fixes

### DIFF
--- a/pages/event-store/usage/installation.mdx
+++ b/pages/event-store/usage/installation.mdx
@@ -135,10 +135,10 @@ npm install --save @ceramic-sdk/events @ceramic-sdk/identifiers @ceramic-sdk/htt
 ```typescript
 import { CeramicClient } from '@ceramic-sdk/http-client';
 
-const client = new CeramicClient('http://localhost:5101');
+const client = new CeramicClient({url: 'http://localhost:5101'});
 
 // Now some calls!
-const response = client.getVersion();
+const response = await client.getVersion();
 
 // Confirm it matches the version you just installed
 console.log(response.version);

--- a/pages/event-store/usage/produce.mdx
+++ b/pages/event-store/usage/produce.mdx
@@ -76,7 +76,8 @@ The `signEvent` function is used to create a signed Ceramic event. It takes a DI
 
 ```typescript
 import { getAuthenticatedDID } from '@didtools/key-did'
-import { InitEventPayload, signEvent } from '@ceramic-sdk/events'
+import { StreamID } from "@ceramicnetwork/streamid";
+import { InitEventPayload, signEvent, signedEventToCAR } from '@ceramic-sdk/events'
 
 // Create an authenticated DID
 const did = await getAuthenticatedDID(new Uint8Array(32))
@@ -90,7 +91,7 @@ const eventPayload: InitEventPayload = {
   data: null,
   header: {
     controllers: [did.id],
-    model: 'yourModelStreamID',
+    model: StreamID.fromString('yourModelStreamID'),
     sep: 'test',
   },
 }
@@ -106,6 +107,12 @@ const encodedPayload = InitEventPayload.encode(eventPayload)
 const signedEvent = await signEvent(did, encodedPayload)
 
 console.log(signedEvent)
+```
+
+### Encode the Signed Event as CAR
+```typescript
+// Convert to an acceptable client payload for client.postEventCAR
+const signedEventAsCar = signedEventToCAR(signedEvent)
 ```
 </Steps>
 


### PR DESCRIPTION
- Fix to incorrect `CeramicClient` instantiation in installation portion
- Fix to event payload instruction to coincide with `InitEventPayload` format in produce section
- Added signed event encoding into the same section as the bullet above for better developer guidance