### PR TITLE
Naming conventions for Ceramic in line with Basin

### DIFF
--- a/pages/ceramic/_meta.json
+++ b/pages/ceramic/_meta.json
@@ -1,0 +1,16 @@
+{
+  "<-": {
+    "title": "Back to home",
+    "href": "/home"
+  },
+  "-": {
+    "title": "Event Storage",
+    "type": "separator"
+  },
+  "index": "Overview",
+  "concepts": "Concepts",
+  "examples": "Examples",
+  "usage": "Usage",
+  "guides": "Guides",
+  "reference": "Reference"
+}

--- a/pages/ceramic/concepts.mdx
+++ b/pages/ceramic/concepts.mdx
@@ -1,0 +1,210 @@
+---
+title: Concepts
+description: Ceramic Terms & Concepts
+---
+
+# Concepts
+
+Ceramic combines a powerful event streaming platform with the open access and verifiability of the
+modern, decentralized web. This page provides a brief overview of the core architecture, with a
+focus on how the high-level components of the protocol fit together.
+
+You may find this page helpful even if you are working with a database or other application built on
+top of the core protocol, such as OrbisDB, although there may be some details here that are less
+relevant to your needs, and some things that are better covered by the documentation of the tool
+you're interacting with directly.
+
+## Event Streaming
+
+### Events
+
+Events are atomic units of information, captured at a point in time and propagated throughout the
+Ceramic network. Events are organized into [streams](#streams), which group related events into a
+sequence and provide a [consistent ordering](#consistent-ordering) that all [consumers](#consumers)
+can agree upon and validate.
+
+Events include a `data` payload, which is a sequence of bytes whose structure and semantics are
+determined by applications building on the Ceramic protocol.
+
+Once an event is published, it is _immutable_ and cannot be altered or deleted. However, by
+leveraging the [data pipeline](#data-pipeline) of an event stream, applications can create mutable
+data structures out of a sequence of immutable events. At present, the primary style of events
+written to streams are JSON-patch updates, making it possible to represent mutable records as the
+aggregation of immutable patches to an initial record state.
+
+### Streams
+
+An event stream contains an ordered sequence of [events](#events). Streams are created by publishing
+an "init event," which contains the identifiers of the [producers](#producers) who are authorized to
+write “data events” into the stream.
+
+The [content identifier (CID)](https://docs.ipfs.tech/concepts/content-addressing/) of the init
+event is used as part of the `StreamId`, which uniquely identifies each stream in Ceramic.
+
+Events published into a stream contain a hash-link to prior events, allowing the full event history
+to be verified for integrity and authenticity.
+
+### Interests
+
+Event consumers can declare “interests” in a selection of the events in the global Ceramic network.
+This allows consumers to receive the events that they care about, without being overwhelmed by event
+streams that are irrelevant to their application. You can think of an interest as a filter on the
+“fire hose” of events flowing through the Ceramic network.
+
+Interests allow Ceramic nodes to efficiently exchange events across the network while optimizing for
+delivery to active consumers. As nodes synchronize with each other, they can prioritize events
+within their respective “interest ranges.”
+
+Interests may describe a data model that an application is concerned with (e.g. activity telemetry
+from an online forum), a user identifier whose data an application wants to persist (e.g. the posts
+and interactions of a single user on a forum), or more abstract qualities (e.g. all posts within a
+certain subforum).
+
+### Producers
+
+Ceramic is an open network, where anyone can submit events into streams that they control. Ceramic
+nodes cooperate to distribute events to all interested consumers, while also validating that events
+have a valid signature from one of the authorized producers declared when the stream was created.
+
+An event producer is identified by a DID, or decentralized identity document. A DID contains either
+a public cryptographic key, or enough information to retrieve and verify a public key from an
+authoritative source.
+
+DIDs serve a similar purpose as “accounts” in most centralized systems, with the distinction that
+they are controlled directly by the creator of the identity and are not issued by a central
+authority. This allows great flexibility, and it ensures that your identity can be used with many
+complementary systems without being tied to any one of them.
+
+Ceramic uses the
+[PKH standard](https://github.com/w3c-ccg/did-pkh/blob/main/did-pkh-method-draft.md) DID method,
+which allows blockchain accounts to sign, authorize, and authenticate Ceramic messages and events.
+Ceramic also supports the [did:key](https://w3c-ccg.github.io/did-method-key/) method which lets
+users directly sign messages with a public key.
+
+### Consumers
+
+Ceramic nodes are continuously synchronizing with one another, distributing messages throughout the
+network and updating their local state as new events come in. When consumers register an
+[interest](#interests) in a selection of events, those events are prioritized and delivered to the
+consuming application.
+
+Applications building on Ceramic can subscribe to event streams and react to events as they arrive.
+Consumers can either handle the event `data` payloads directly using their own bespoke processing,
+or they can leverage Ceramic's standard data pipeline to combine messages into new forms, including
+mutable data structures and other key components of a modern data environment.
+
+## Archival Storage on Hoku
+
+The Ceramic Network in the context of Hoku is a communication, synchronization, and validation for
+ephemral events. While this architecture is intentionally flexible to allow for bespoke molding of
+custom data pipelines, schema, and other logic, it requires a data availability layer to provide
+archival assurances and programmatic access.
+
+To accommodate this need, Ceramic events are aggregated into parquet files as they undergo
+transformations across the Ceramic data pipeline, giving developers access to raw events, resolved
+document states, or custom document states based on bespoke logic developers implement into their
+pipelines.
+
+These parquet files containing Ceramic events are stored in Hoku's Object Storage solution, Basin.
+The columnar storage format of parquet files is highly efficient for analytical queries, therefore
+reducing data transfer and storage costs. Parquet also supports performant compression schemes which
+reduces file sizes further without compromising performance.
+
+## Data Pipeline
+
+The pipeline architecture processes Ceramic data through a series of transformations that define
+features and enable diverse functionalities. Data enters the system via its API and is first stored
+in the raw_events table. It then undergoes sequential transformations that generate intermediate
+tables, each designed to organize and enrich the data. These tables, with schemas treated as public
+APIs, provide structured access and support specific query patterns for interacting with the data
+using Flight SQL.
+
+```mermaid
+graph LR;
+    raw_events;
+    streams;
+    chain_proofs;
+    conclusion_events;
+    model_schemas;
+    event_states;
+    stream_tips;
+    stream_states;
+
+    raw_events --> conclusion_events;
+    streams --> conclusion_events;
+    chain_proofs --> conclusion_events;
+    conclusion_events --> event_states;
+    model_schemas --> event_states;
+    event_states --> stream_tips;
+    stream_tips --> stream_states;
+```
+
+### raw_events
+
+The raw_events table contains the raw event data from Ceramic streams, including the corresponding
+CAR files. This table enables direct interaction with event data for validation and further
+processing.
+
+### streams
+
+The streams table provides identifying information for each stream, such as its type, controller,
+and dimensions. It serves as a central reference for understanding and querying stream metadata.
+
+### chain_proofs
+
+The chain_proofs table contains records of onchain proofs for events, supporting verification and
+validation processes. (Schema and population details are TBD.)
+
+### conclusion_events
+
+The conclusion_events table holds transformed event data with resolved dimensions, controller
+information, and validated signatures, facilitating pre-aggregated queries and stream ordering.
+
+### model_schemas
+
+The model_schemas table contains fully resolved schemas for models, supporting schema validation and
+providing a reference for stream structure. (Further schema and population details are TBD.)
+
+### event_states
+
+The event_states table tracks the document state at each event within a stream, providing access to
+the complete history and enabling validation against model schemas.
+
+### stream_tips
+
+The stream_tips table identifies the current tips of streams, representing the latest unresolved
+states for developers working on conflict resolution systems.
+
+### stream_states
+
+The stream_states table provides the canonical state for each stream after applying conflict
+resolution, offering a reliable snapshot of stream data for consumers.
+
+_For a more detailed breakdown of each table, please visit the
+[Pipeline Architecture](https://github.com/ceramicnetwork/rust-ceramic/pipeline/DESIGN.md)
+overview._
+
+### Models & Documents
+
+While events are a powerful and flexible basis for a data platform, they aren't always a perfect fit
+for “application level” data modeling. Using the aggregation framework, events can be combined to
+form structured documents that can evolve over time.
+
+Documents are conceptually just JSON objects. The initial state of the document is included in the
+“init event” of a Ceramic stream, and the `StreamId` is used to identify the document and listen for
+future update events. Updates to documents take the form of events containing JSON patch objects
+which encode an operation to perform on the current state, for example, set the field `"name"` to
+the value `"Ada Lovelace"`.
+
+Databases built on Ceramic like OrbisDB extend the idea of JSON-based documents and defines a shared
+vocabulary of “models.” A model specifies the fields, data types, and relationships to other models
+that are supported for a specific kind of data. For example, a simple social media post model might
+include a text status field, a link to the author's account, and optional links to attached media
+objects.
+
+In Ceramic, models are associated with the model instance document stream type. Ceramic is, however,
+designed with the flexibility to process events for various stream types, with models representing
+just one stream category. Therefore, it is important to note that the data pipeline steps outlined
+above will vary based on different stream types. While Ceramic currently only supports model and
+model instance document streams, support for new stream types will be introduced by implementing
+their pipeline aggregation steps in the near future.

--- a/pages/ceramic/examples.mdx
+++ b/pages/ceramic/examples.mdx
@@ -1,0 +1,21 @@
+---
+title: Examples
+description: Examples of Ceramic in Action
+---
+
+# Examples
+
+Today, Ceramic powers a handful of bespoke products that process composable data in unique ways.
+Ceramic's stream primitives make it a great solution for databases that index data in various ways
+as well as for aggregation pipelines.
+
+### SQL Databases
+
+[OrbisDB](https://useorbis.com/) is a SQL database built on JSON document aggregations, powered by
+Ceramic streams and the [aggregation library](#).
+
+### Vector / AI Databases
+
+[Index](https://index.network/) is a vector database that makes it possible for AI agents to compute
+vector embeddings of data sets and compose with one another to provide search and alerting services
+over broad, public and private datasets.

--- a/pages/ceramic/guides/access-control.mdx
+++ b/pages/ceramic/guides/access-control.mdx
@@ -1,0 +1,8 @@
+---
+title: Access control
+description: Description here
+---
+
+_TODO_
+
+ACL stuff

--- a/pages/ceramic/guides/cloud-deployments.mdx
+++ b/pages/ceramic/guides/cloud-deployments.mdx
@@ -1,0 +1,6 @@
+---
+title: Cloud deployments
+description: Description here
+---
+
+_TODO_

--- a/pages/ceramic/guides/topics-interests.mdx
+++ b/pages/ceramic/guides/topics-interests.mdx
@@ -1,0 +1,6 @@
+---
+title: Topics & interests
+description: Description here
+---
+
+_TODO_

--- a/pages/ceramic/index.mdx
+++ b/pages/ceramic/index.mdx
@@ -1,0 +1,36 @@
+---
+title: Overview
+description:
+  Offchain event store for applications requiring mutable records or online aggregations over
+  streams of data.
+---
+
+import { Cards, Card } from "nextra/components";
+
+Ceramic is a decentralized data network provides Web3 developers with a collection of features that
+make it possible to build scalable Web3 applications with composable data that can be reused and
+shared across applications. Data written to Ceramic has the following unique properties:
+
+- **Verifiability**: All data written to Ceramic is signed by its author, meaning data on Ceramic is
+  self-certifying and trustworthy.
+- **Composability**: Data in Ceramic is organized by [models](/event-store/concepts). When
+  applications use the same data models, the data they create can be viewed as one, universal
+  dataset. Ceramic makes it easy to compose data from distinct applications and users into a single,
+  hackable dataset.
+- **Scalable**: Data in Ceramic is sharded by author by default. In exchange for giving up
+  transactionality, Ceramic elegantly scales to massive datasets.
+- **Secure**: Ceramic gains a sense of time by [anchoring](#) its data to a blockchain, which allows
+  Ceramic nodes to assert when data was created. Ceramic uses this sense of time to implement
+  expiring user sessions, meaning one compromised session keypair doesn't permanently taint a user's
+  identity.
+- **Private**: Ceramic makes it possible for users to determine what data is shared with which
+  entities at what time.
+
+## Contents
+
+<Cards>
+  <Card title="Concepts" href="/event-store/concepts" />
+  <Card title="Examples" href="/event-store/examples" />
+  <Card title="Installation" href="/event-store/usage/installation" />
+  <Card title="TODO" href="/" />
+</Cards>

--- a/pages/ceramic/reference/_meta.json
+++ b/pages/ceramic/reference/_meta.json
@@ -1,0 +1,6 @@
+{
+  "errors": "Errors",
+  "faqs": "FAQs",
+  "testing": "Testing",
+  "http": "HTTP API"
+}

--- a/pages/ceramic/reference/errors.mdx
+++ b/pages/ceramic/reference/errors.mdx
@@ -1,0 +1,6 @@
+---
+title: Errors
+description: Description here
+---
+
+_TODO_

--- a/pages/ceramic/reference/faqs.mdx
+++ b/pages/ceramic/reference/faqs.mdx
@@ -1,0 +1,6 @@
+---
+title: FAQs
+description: Description here
+---
+
+_TODO_

--- a/pages/ceramic/reference/http.mdx
+++ b/pages/ceramic/reference/http.mdx
@@ -1,0 +1,234 @@
+---
+title: HTTP API
+description: The Hoku Event Store HTTP API
+---
+
+import { Callout } from "nextra/components";
+
+<Callout>
+  Just getting started? Check out our Getting Connected Guide to get your client setup This document
+  assumes that you've already followed our [installation guide](/event-store/usage/installation)
+</Callout>
+
+<Callout type="info">
+  This document describes the underlying HTPT API leveraged by the Hoku Event Store SDK. This is
+  primarily for reference purposes, but will be useful for anyone wishing to build their own client
+  libraries for Hoku Event Store.
+</Callout>
+
+Ceramic nodes provide an HTTP API that exposes the core functionality of the node to applications,
+including the official command line tools. The JavaScript Ceramic SDK uses the HTTP API to interact
+with the Ceramic network, and it is a good reference for those interested in developing client SDKs
+in other languages.
+
+In the examples below, we'll use `curl` to make requests to a
+[ceramic-one](https://github.com/ceramicnetwork/rust-ceramic) node, similar to the following:
+
+```jsx
+curl $CERAMIC_API/feed/events
+```
+
+For easier copy and paste, we'll save the base URL of the node's HTTP API into an environment
+variable called `CERAMIC_API` in our shell. For “bash-like” shells, run this to target a node
+running on the local machine with its default port:
+
+```jsx
+CERAMIC_API=http://localhost:8080/ceramic
+```
+
+If you are targeting a remote node or are running on a different port, please replace the URL as
+needed.
+
+## Event Ids and Payloads
+
+The Ceramic event API returns event objects with the following structure:
+
+```jsx
+{
+  "id": "string",
+  "data": "string"
+}
+```
+
+The `data` field contains the binary event payload encoded as a multibase string. Multibase is a
+“self describing” format for encoding binary data into strings using various alphabets and encoding
+conventions.
+
+The binary data is a Content Archive (or “CAR”), which is a data format defined by the
+InterPlanetary Linked Data (”IPLD”) project. CARs contain a collection of content-addressed binary
+“blocks,” which can be linked together using the Content Identifier (or “CID”) of each block.
+
+The links between blocks form a graph with one block at the “root” of the graph, meaning that all
+the other blocks are reachable by following links from the root block. The CID of this root block is
+the ID of the event. The `id` field of the event object JSON object shown above is the
+string-encoded CID of the event's root block.
+
+The inner structure of the CAR, including the format of the data within blocks, can vary depending
+on the type of event and is not detailed here. (TODO: link to docs on model & document event
+structures)
+
+## Usage
+
+_How to use the Ceramic HTTP API._
+
+### Fetching a single event
+
+**`GET /events/{event_id}`**
+
+To retrieve a single event, send a GET request to `/events/{event_id}`, where `{event_id}` is the
+string-encoded CID of the event's root block.
+
+```jsx
+curl $CERAMIC_API/events/$MY_EVENT_ID
+```
+
+**Response:**
+
+On success, returns a JSON event object as
+[described above](https://www.notion.so/Hoku-Docs-3cc94cbd965843288f7d8190010d6249?pvs=21):
+
+```jsx
+{
+  "id": "string",
+  "data": "string"
+}
+```
+
+### Reading from the event feed
+
+The `/feed` endpoints provide access to the feed of all events flowing through the ceramic node.
+
+As a consumer, you do not need to maintain a persistent connection to the node in order to receive
+all events. Instead, you supply a “resume token” with each request to the `GET /feed/events`
+endpoint, and the node will respond with all events that follow the resume token's place in the
+event stream's history.
+
+**`GET /feed/events`**
+
+Returns all events following the `resumeAt` query parameter, up to a configurable `limit`.
+
+```jsx
+curl $CERAMIC_API/feed/events?resumeAt="token-from-previous-response"
+```
+
+**Parameters**:
+
+- `resumeAt` - a resume token that specifies what point in the feed to resume from. This can be
+  obtained from a previous response to `/feed/events`, or from the `/feed/resumeToken` endpoint.
+- `limit` (optional) - the maximum number of events to return. Defaults to ten thousand.
+
+**Response**:
+
+Returns a JSON object with the following structure:
+
+```jsx
+{
+  "events": [
+    {
+      "id": "string",
+      "data": "string"
+    }
+  ],
+  "resumeToken": "string"
+}
+```
+
+The `events` array contains event JSON objects as [described above](#event-ids-and-payloads).
+
+The `resumeToken` in the response can be used as the `resumeAt` parameter for a subsequent call to
+`/feed/events` to obtain the next page of results.
+
+**`GET /feed/resumeToken`**
+
+When you first subscribe to the event feed, you will not have a resume token to supply as the
+`resumeAt` parameter for the `/feed/events` endpoint. To obtain the initial token, make a GET
+request to `/feed/resumeToken` to receive a token for the current “tip” of the feed. Effectively,
+this lets you start the feed from “right now.”
+
+```jsx
+curl $CERAMIC_API/feed/resumeToken
+```
+
+**Response:**
+
+Returns a JSON object with a `resumeToken` string field that can be used as the `resumeAt` parameter
+for the `/feed/events` endpoint.
+
+```jsx
+{
+  "resumeToken": "string"
+}
+```
+
+### Publishing Events
+
+You can publish events to the Ceramic network by sending a POST request to `/events` . The request
+payload must be a JSON object with a string `data` field:
+
+```jsx
+{
+  "data": "string"
+}
+```
+
+The `data` field must contain a multibase-encoded Content Archive (CAR) of event data, as
+[described above](#event-ids-and-payloads).
+
+**Response:**
+
+Because event ids are deterministic and depend only on the event data, it is assumed that clients
+will compute the event id as part of the process of constructing events. As such, there is no need
+to return an event id on publication, and the `POST /events` endpoint returns a 200 status code with
+no response body on success.
+
+### Register an Interest
+
+TODO: describe interests & how to POST to `/interests`
+
+```jsx
+
+```
+
+### Read Events Related to an Interest
+
+TODO: describe `/experimental/events/{sep}/{sepValue}`
+
+```jsx
+
+```
+
+## Status
+
+The API provides a few endpoints that return status information about the node.
+
+### Liveness
+
+You can “ping” the node to check that it’s operational by sending a GET request to `/liveness` which
+will return a 200 status code with no response body if the node is in good health. If there’s a
+problem, it will return a 500 response with an object containing an error `message`:
+
+```jsx
+{
+  "message": "string"
+}
+```
+
+### Version
+
+You can retrieve the version of the node by sending a GET request to `/version` which will return a
+JSON object with a `version` string field:
+
+```jsx
+{
+  "version": "string"
+}
+```
+
+## Debugging
+
+### Heap statistics
+
+The `/debug/heap` endpoint returns heap usage statistics for the Ceramic node, which may be useful
+when debugging a node's performance and resource utilization. On success, a GET request to
+`/debug/heap` will return profiling information as a binary payload in the
+[`pprof` format.](https://github.com/google/pprof/tree/main/proto)

--- a/pages/ceramic/reference/testing.mdx
+++ b/pages/ceramic/reference/testing.mdx
@@ -1,0 +1,6 @@
+---
+title: Testing
+description: Description here
+---
+
+_TODO_

--- a/pages/ceramic/usage/_meta.json
+++ b/pages/ceramic/usage/_meta.json
@@ -1,0 +1,6 @@
+{
+  "installation": "Installation",
+  "produce": "Produce",
+  "consume": "Consume",
+  "query": "Query"
+}

--- a/pages/ceramic/usage/consume.mdx
+++ b/pages/ceramic/usage/consume.mdx
@@ -1,0 +1,139 @@
+---
+title: Consume
+description: Consume events from a stream
+---
+
+import { Steps, Callout } from "nextra/components";
+
+<Callout>
+  Just getting started? Check out our Getting Connected Guide to get your client setup This document
+  assumes that you've already followed our [installation guide](/event-store/usage/installation)
+</Callout>
+
+Let's explore how use Ceramic to read messages from a stream. Ceramic nodes in the Hoku network
+subscribe to data by expressing an [interest](/event-store/concepts#interests) in a given data
+model. This interest is broadcast to the node's peers in the network, who will then initiate
+periodic synchronization of all data conforming to that model via [Recon](#), a protocol tailor-made
+for the efficient synchronization of large sets of events.
+
+## Consuming events
+
+First, we'll learn how to register an interest. Then we'll learn how to read events matching our
+interests. Finally, we'll learn about some extra methods to fetch specific events from your
+ceramic-one node.
+
+### `registerInterestModel`
+
+This method allows end users to register interest in a specific data model within the Ceramic
+network. The model's identifier is, itself, the ID of a stream that defines its schema.
+
+```typescript
+// My moddel stream ID
+const modelId = "kjzl6hvfrbw6c5i55ks5m4hhyuh0jylw4g7x0asndu97i7luts4dfzvm35oev65";
+
+// Listen to all events written to instances of this modela
+await ceramic.registerInterestModel(model);
+```
+
+Upon success, the function won't return anything, but it will throw if there's an issue. You're now
+ready to read events from streams tied to this schema!
+
+### `getEventsFeed`
+
+This method allows users to poll for new events that match their interests. It follows a typical
+pagination screen, in which users may specify `limit`, the maxinum number of results to return in a
+given query, and `resumeAt` an opaque token that the ceramic-one node can use to determine where the
+user left off in their last read.
+
+<Steps>
+
+### Prepare your request parameters
+
+Let's assume I want to read 50 events matching my interests. Both of these parameters are optional,
+but we'll define them to illustrate their purpose. If no limit is defined, the SDK will retrieve all
+new events from the resume token.
+
+```typescript
+const params: EventFeedParams = {
+  limit: 50,
+  resumeAt: "myResumeToken", // The resumeToken returned from the last call to `getEventsFeed`
+};
+```
+
+### Get a batch of events
+
+```typescript
+const events = await ceramic.getEventsFeed(params);
+```
+
+If there is an issue, `getEventsFeed` will throw. Otherwise, you'll get an object shaped like this:
+
+```typescript
+type EventsFeed = {
+  events: {
+    id: string;
+    data?: string;
+  }[];
+  resumeToken: string;
+};
+```
+
+</Steps>
+
+### Getting individual events
+
+Ceramic also offers a handful of simple APIs to fetch individual events from your ceramic-one node.
+
+#### `getEvent`
+
+This is the most straightforward of the event fetching methods. It returns an event of the form:
+
+```typescript
+type Event = {
+  id: string;
+  data?: string;
+};
+```
+
+To fetch an event by it's id, we use `getEvent`
+
+```typescript
+const event = await ceramic.getEvent(myEventId);
+```
+
+There are also a small collection of simple helper functions to extract specific parts of an event.
+
+#### `getEventData`
+
+Extract the data payload from an event.
+
+```typescript
+const data = await ceramic.getEventData(myEventId);
+```
+
+This is equivalent to
+
+```typescript
+ceramic.getEvent(myEventId).then((event) => event.data);
+```
+
+#### `getEventCAR`
+
+Extract the data payload from an event and parse it as a CAR file.
+
+```typescript
+const data = await ceramic.getEventCAR(myEventId);
+```
+
+`data` will be the parsed payload of the event.
+
+#### `getEventType`
+
+This method is useful for cases where you know the schema of the payload. To use it, you must have a
+[codeco](https://github.com/ceramicnetwork/codeco) codec handy.
+
+```typescript
+type MyPayload = /* ... */;
+const decoder: Decoder<unknown, MyPayload> = /* ... */;
+const data: MyPayload = await ceramic.getEventType(decoder, myEventId);
+```

--- a/pages/ceramic/usage/installation.mdx
+++ b/pages/ceramic/usage/installation.mdx
@@ -1,0 +1,154 @@
+---
+title: Installation
+description: Getting Started With the Ceramic SDK
+---
+
+import { Steps } from "nextra/components";
+
+The [Ceramic SDK](https://github.com/ceramicstudio/ceramic-sdk) enables user to interact with the
+Ceramic's primitive APIs for creating streams as well as producing events on streams, consuming
+events from streams, and aggregating stream state. Find it on GitHub at
+https://github.com/ceramicstudio/ceramic-sdk.
+
+The SDK is written in TypeScript and published to NPM as `@ceramic-sdk`, with a handful of useful
+sub-packages:
+
+- `@ceramic-sdk/events`: Utilities for creating and signing events that comply to the
+  [Hoku Event Store standards.](https://developers.ceramic.network/docs/protocol/js-ceramic/streams/event-log)
+- `@ceramic-sdk/http-client`: A simple client for
+  [ceramic-one's](https://github.com/ceramicnetwork/rust-ceramic) HTTP APIs.
+- `@ceramic-sdk/identifiers`: A handful of useful types for identifying streams and events.
+
+The Ceramic SDK needs a [ceramic-one](https://github.com/ceramicnetwork/rust-ceramic) daemon to
+connect to.
+
+Let's get them all installed!
+
+<Steps>
+  
+### Install ceramic-one
+
+ceramic-one can run on macOS, Linux, or from within a docker container.
+
+#### MacOS
+
+Install from [Homebrew](https://brew.sh/):
+
+```bash
+brew install ceramicnetwork/tap/ceramic-one
+```
+
+#### Linux (Debian-based distributions)
+
+Install a the latest release using dpkg:
+
+```bash
+# get deb.tar.gz
+curl -LO https://github.com/ceramicnetwork/rust-ceramic/releases/download/latest/ceramic-one_x86_64-unknown-linux-gnu.tar.gz
+# untar the Debian software package file
+tar zxvf ceramic-one_x86_64-unknown-linux-gnu.tar.gz
+# install with dpkg - package manager for Debian
+dpkg -i ceramic-one.deb
+```
+
+#### Linux (from Source)
+
+```bash
+# Install rust
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+# Install build tools
+apt-get install -y build-essential pkg-config openssl libssl-dev unzip
+# Update environment
+source "$HOME/.cargo/env"
+# Install protobuf
+PROTOC_VERSION=3.20.1
+PROTOC_ZIP=protoc-$PROTOC_VERSION-linux-x86_64.zip
+curl --retry 3 --retry-max-time 90 -OL https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOC_VERSION/$PROTOC_ZIP \
+    && unzip -o $PROTOC_ZIP -d /usr/local bin/protoc \
+    && unzip -o $PROTOC_ZIP -d /usr/local 'include/*' \
+    && rm -f $PROTOC_ZIP
+# Checkout rust-ceramic repo
+git clone https://github.com/ceramicnetwork/rust-ceramic
+# Enter repo and build
+cd rust-ceramic
+make build
+cp ./target/release/ceramic-one /usr/local/bin/ceramic-one
+```
+
+#### Docker
+
+Start rust-ceramic using the host network:
+
+```bash
+docker run --network=host \
+  public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest
+```
+
+#### Docker-Compose
+
+1. Create a testing directory, and enter it:
+
+```bash
+mkdir ceramic-recon
+cd ceramic-recon
+```
+
+2. Save the following docker-compose.yaml there:
+
+```YAML
+version: '3.8'
+
+services:
+  ceramic-one:
+    image: public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest
+    network_mode: "host"
+    volumes:
+      - ceramic-one-data:/root/.ceramic-one
+volumes:
+  ceramic-one-data:
+    driver: local
+```
+
+3. Run `docker-compose up -d`
+
+### Run the ceramic-one daemon
+
+```bash
+# if necessary, include the path/to/the/binary e.g. /usr/local/bin/ceramic-one or ./target/release/ceramic-one
+$ ceramic-one daemon
+
+# There are many flags for the daemon CLI that can be passed directly or set as environment variables.
+# See `DaemonOpts` in one/src/lib.rs for the complete list or pass the -h flag
+$ ceramic-one daemon -h
+
+# A few common options are overriding the log level:
+$ RUST_LOG=warn,ceramic_one=info,ceramic_service=debug ceramic-one daemon
+# Or modifying the network
+$ ceramic-one daemon --network testnet-clay
+$ ceramic-one daemon --network local --local-network-id 0
+# Or changing where directory where all data is stored. This folder SHOULD be backed up in production
+# and if you change the defaults, you MUST specify it every time you start the daemon.
+$ ceramic-one daemon --store-dir ./custom-store-dir
+```
+
+### Add client packages to your project
+
+```bash
+npm install --save @ceramic-sdk/events @ceramic-sdk/identifiers @ceramic-sdk/http-client
+```
+
+### Set up your client
+
+```typescript
+import { CeramicClient } from "@ceramic-sdk/http-client";
+
+const client = new CeramicClient({ url: "http://localhost:5101" });
+
+// Now some calls!
+const response = await client.getVersion();
+
+// Confirm it matches the version you just installed
+console.log(response.version);
+```
+
+</Steps>

--- a/pages/ceramic/usage/produce.mdx
+++ b/pages/ceramic/usage/produce.mdx
@@ -1,0 +1,229 @@
+---
+title: Produce
+description: Produce Events on a stream
+---
+
+import { Steps, Callout } from "nextra/components";
+
+<Callout>
+  Just getting started? Check out our Getting Connected Guide to get your client setup This document
+  assumes that you've already followed our [installation guide](/event-store/usage/installation)
+</Callout>
+
+Let's explore how to use Ceramic to send messages between clients. If you've followed our
+[Getting Started guide](/event-store/usage/installation), you should have a `CeramicClient`
+connected to a Ceramic node, as well as a `DID` that can sign and publish events. We'll use these to
+create new signed events and submit them to the Ceramic network.
+
+In the examples below, the `CeramicClient` is stored in a variable named `ceramic`, and the DID used
+for publishing is in a variable named `publisherDID`. If you've used different names, please adjust
+the examples to match your preferences.
+
+## Publishing events
+
+The `CeramicClient` includes a few methods for event publishing, most of which are convenience
+wrappers around the fundamental `postEvent` method.
+
+### `postEvent`
+
+The foundational method for publishing events is `postEvent`, which accepts a binary event payload
+that's been encoded into a string using the [multibase encoding standard][ref-multibase].
+
+The event payload is a Content Archive or [CAR][ref-car], which contains "blocks" of
+content-addressed data, including the event data and the signature from the publisher's DID. Soon
+we'll learn how to produce events in the correct format, but for the example below, we'll assume
+that you have already created an event and encoded it to a multibase string in the variable
+`encodedEvent`:
+
+```tsx
+await ceramic.postEvent(encodedEvent);
+```
+
+The `postEvent` method returns a `Promise<void>` which resolves with no value on success, or throws
+an `Exception` if the event submission fails. Because event ids are deterministic, there's no need
+to wait for a response to know the identifier of the event. See the [event ids][docs-event-ids]
+documentation for more about determining the id for an event or stream.
+
+### `postEventCAR`
+
+A convenience wrapper around [`postEvent`](#postevent) which accepts a [CAR][ref-car] JavaScript
+object and encodes it to the string format that `postEvent` expects.
+
+```tsx
+import { eventToCAR } from "@ceramic-sdk/events";
+
+// assume that we have an `eventData` object and an `eventCodec` that
+// can encode and decode events of a particular type
+const eventCAR = eventToCAR(eventCodec, eventData);
+
+await ceramic.postEventCAR(eventCAR);
+```
+
+### `postEventType`
+
+**This is the method most users will want to use to produce events on a stream.**
+
+The `postEventType` method accepts event data in an arbitrary format, and uses a
+[codeco](https://github.com/ceramicnetwork/codeco) `Codec` to convert the event data into a properly
+encoded CAR, which it then passes into [`postEvent`](#postevent).
+
+```tsx
+// assume that we have an `eventData` object and an `eventCodec` that
+// can encode and decode events of a particular type
+
+await ceramic.postEventType(eventCodec, eventData);
+```
+
+If you need access to the event data in CAR format before submitting it for publication, for example
+to record the event id locally, you can call the `eventToCAR` method from the `@ceramic-sdk/events`
+package and send the result to [`postEventCAR`](#posteventcar).
+
+In the [Creating Events](#creating-events) section below, we'll see some of the built-in `Codec`s
+provided by the `@ceramic-sdk/events` package, which can handle common event structures like Model
+and Document creation and update events.
+
+## Creating Events
+
+Events can be constructed from either a string representation or a Content Addressable aRchive (CAR)
+file. The `@ceramic-sdk/events` package provides two main functions for this purpose:
+`eventFromString` and `eventFromCAR`.
+
+### `signEvent`
+
+The `signEvent` function is used to create a signed Ceramic event. It takes a DID (Decentralized
+Identifier), a payload, and optional JWS creation options, and returns a `SignedEvent`.
+
+<Steps>
+### Import functions and create a DID
+
+```typescript
+import { getAuthenticatedDID } from "@didtools/key-did";
+import { StreamID } from "@ceramicnetwork/streamid";
+import { InitEventPayload, signEvent, signedEventToCAR } from "@ceramic-sdk/events";
+
+// Create an authenticated DID
+const did = await getAuthenticatedDID(new Uint8Array(32));
+```
+
+### Construct an event payload
+
+```typescript
+// Create an event payload
+const eventPayload: InitEventPayload = {
+  data: null,
+  header: {
+    controllers: [did.id],
+    model: StreamID.fromString("yourModelStreamID"),
+    sep: "test",
+  },
+};
+```
+
+### Sign the payload
+
+```typescript
+// Encode the payload
+const encodedPayload = InitEventPayload.encode(eventPayload);
+
+// Sign the event
+const signedEvent = await signEvent(did, encodedPayload);
+
+console.log(signedEvent);
+```
+
+### Encode the Signed Event as CAR
+
+```typescript
+// Convert to an acceptable client payload for client.postEventCAR
+const signedEventAsCar = signedEventToCAR(signedEvent);
+```
+
+</Steps>
+
+### `eventFromString`
+
+The `eventFromString` function allows you to construct a Ceramic event from a string representation.
+This is useful when you have received event data as a string, typically encoded in base64.
+
+<Steps>
+
+### Import functions
+
+```typescript
+import { eventFromString, InitEventPayload } from "@ceramic-sdk/events";
+```
+
+### Decode the event
+
+```typescript
+// Assuming you have a base64 encoded string representation of an event
+const encodedEvent = "base64EncodedEventString";
+
+// Decode the event
+const decodedEvent = eventFromString(InitEventPayload, encodedEvent);
+```
+
+### Inspect the decoded event
+
+```typescript
+// The decodedEvent will be either a SignedEvent or an InitEventPayload
+if (SignedEvent.is(decodedEvent)) {
+  console.log("This is a signed event");
+} else {
+  console.log("This is an unsigned event payload");
+}
+```
+
+</Steps>
+
+### `eventFromCAR`
+
+The `eventFromCAR` function allows you to construct a Ceramic event from a Content Addressable
+aRchive (CAR).
+
+<Steps>
+
+### Import functions and set up a DID
+
+```typescript
+import {
+  InitEventPayload,
+  eventFromCAR,
+  encodeEventToCAR,
+  signedEventToCAR,
+  SignedEvent,
+} from "@ceramic-sdk/events";
+import { getAuthenticatedDID } from "@didtools/key-did";
+import { randomStreamID } from "@ceramic-sdk/identifiers";
+import { asDIDString } from "@didtools/codecs";
+import { signEvent } from "@ceramic-sdk/events";
+
+// Create an authenticated DID
+const did = await getAuthenticatedDID(new Uint8Array(32));
+```
+
+### Construct and sign the CAR
+
+```typescript
+// Create a test event payload
+const testEventPayload: InitEventPayload = {
+  data: null,
+  header: {
+    controllers: [asDIDString(did.id)],
+    model: randomStreamID(),
+    sep: "test",
+  },
+};
+
+// Encode the test payload
+const encodedTestPayload = InitEventPayload.encode(testEventPayload);
+const signedEvent = await signEvent(did, encodedTestPayload);
+```
+
+### Construct the event
+
+```typescript
+const event = eventFromCAR(InitEventPayload, unsignedCAR);
+```
+
+</Steps>

--- a/pages/ceramic/usage/query.mdx
+++ b/pages/ceramic/usage/query.mdx
@@ -1,0 +1,90 @@
+---
+title: Query the Pipeline
+description: Query table states across Ceramic's data pipeline
+---
+
+import { Steps, Callout } from "nextra/components";
+
+<Callout>
+  Just getting started? Check out our Getting Connected Guide to get your client setup This document
+  assumes that you've already followed our [installation guide](/event-store/usage/installation)
+</Callout>
+
+Streaming systems are invaluable in modern data architectures due to their ability to process and
+analyze data in real-time as it flows through a system. One of the primary use cases that makes
+streaming systems so powerful is aggregation. By continuously processing incoming events, streaming
+systems allow for the dynamic creation and updating of table views, providing up-to-the-moment
+insights without the need for batch processing. This real-time data transformation capability
+enables applications to maintain live dashboards, detect anomalies instantly, and make data-driven
+decisions with minimal latency. Ceramic offers a powerful data pipeline suitable for a variety of
+workloads.
+
+## Flight SQL library
+
+Flight SQL is a protocol designed efficiently handling and querying large-scale analytical data by
+extending [Apache Arrow Flight](https://arrow.apache.org/blog/2019/10/13/introducing-arrow-flight/),
+an RPC protocol built for high-performance data transfer in big data application settings.
+
+Ceramic nodes expose a Flight SQL endpoint which allows developers to query the various parquet
+tables across the Ceramic data pipeline.
+
+### Why Flight SQL?
+
+Flight SQL organizes data into columnar format for fast, memory-efficient data handling, thus
+reducing the amount of time needed to serialize, deserialize, and transfer data between clients and
+servers. At the same time, Flight SQL supports SQL queries, making it highly useful for applications
+requiring SQL analytics.
+
+Since Flight SQL's protocol is tailored for high-throughput data transport across networks, this
+makes it ideal for moving large, columnar data (like Parquet) over the network between distributed
+systems. Furthermore, Parquet data can be loaded into an Arrow-based in-memory format and then
+queried and transmitted efficiently, ideal for intense data workloads.
+
+## Set up your client
+
+The `@ceramic-sdk/flight-sql-client` is a package designed to run server-side only. Using this
+client needs a [ceramic-one](https://github.com/ceramicnetwork/rust-ceramic) daemon running with
+experimental flags which point to your Basin-S3 adapter:
+
+```bash
+ceramic-one -- daemon --experimental-features --flight-sql-bind-address 0.0.0.0:5102 --s3-bucket your-basin-account.your-bucket-name
+```
+
+<Steps>
+### Install the flight-sql package
+
+```bash
+npm install --save @ceramic-sdk/flight-sql-client
+```
+
+### Create a client instance
+
+```typescript
+import { createFlightSqlClient, ClientOptions } from "@ceramic-sdk/flight-sql-client";
+import { tableFromIPC } from "apache-arrow";
+
+const OPTIONS: ClientOptions = {
+  headers: new Array(),
+  username: undefined,
+  password: undefined,
+  token: undefined,
+  tls: false,
+  host: "127.0.0.1",
+  port: 5102,
+};
+
+const client = await createFlightSqlClient(OPTIONS);
+```
+
+### Execute a query
+
+```typescript
+// query the event_states table to access aggregated document state
+const data = await client.runQuery("SELECT * FROM event_states");
+
+// deserialize the IPC format into a table
+const table = tableFromIPC(buffer);
+console.log(JSON.stringify(table));
+```
+
+</Steps>

--- a/pages/home/_meta.json
+++ b/pages/home/_meta.json
@@ -21,9 +21,9 @@
     "title": "Basin",
     "href": "/basin"
   },
-  "event-store": {
-    "title": "Event store",
-    "href": "/event-store"
+  "ceramic": {
+    "title": "Ceramic",
+    "href": "/ceramic"
   },
   "databases": {
     "title": "Databases",


### PR DESCRIPTION
- Change /event-store directory to /ceramic (in line with Basin)
- Change sidebar subtitle to "Event Storage"