### PR TITLE
docs: improve text clarity

### DIFF
--- a/docs/agents/access.mdx
+++ b/docs/agents/access.mdx
@@ -19,7 +19,7 @@ access control to help with _both_ read and write access patterns. You can learn
 
 ## Access control
 
-All access control patterns are handled for write operations. The credit system is can be used to
+All access control patterns are handled for write operations. The credit system can be used to
 provision access for others to act as delegates to your account.
 
 For example, by creating credit approvals from your account `A`, you can:

--- a/docs/agents/plugins/eliza/cot.mdx
+++ b/docs/agents/plugins/eliza/cot.mdx
@@ -10,7 +10,7 @@ Thought logs from your agent and inspect them with Recall tools or the Portal.
 <Callout>
 
 Detailed documentation on how to use the plugin is coming soon; we're awaiting the plugin to be
-merged into the the [Eliza](https://github.com/elizaOS/eliza) repo. For now, review the quickstart
+merged into the [Eliza](https://github.com/elizaOS/eliza) repo. For now, review the quickstart
 guide, which walks through our agent starter kit: [here](/intro/quickstarts/eliza).
 
 </Callout>

--- a/docs/agents/plugins/game/s3.mdx
+++ b/docs/agents/plugins/game/s3.mdx
@@ -198,7 +198,7 @@ async function main() {
   const task1 =
     "Upload a file to the S3 bucket at the path `./package.json` with key `hello/world` and use a signed URL with a TTL of 900 seconds";
   const task2 =
-    "Download a file from the S3 bucket at key `hello/world` to the a file at `./test.txt`";
+    "Download a file from the S3 bucket at key `hello/world` to the file at `./test.txt`";
 
   // Run the tasks
   await agentS3Worker.runTask(task1, {

--- a/docs/intro/quickstarts/eliza.mdx
+++ b/docs/intro/quickstarts/eliza.mdx
@@ -169,7 +169,7 @@ Agent: ✅ Successfully created or retrieved bucket **"recall-agent"** at addres
 ```
 
 The step above will log information about what the agent is doing, but this is _only_ available
-locally. Fore example, it's printed to the console, and only certain pieces might be included in the
+locally. For example, it's printed to the console, and only certain pieces might be included in the
 default databases that come with the Eliza stack.
 
 ```

--- a/docs/protocol/contracts/index.mdx
+++ b/docs/protocol/contracts/index.mdx
@@ -11,7 +11,7 @@ and available RPCs. The RPCs and APIs listed below are public endpoints for Reca
 core team. The descriptions below break down the core contracts and their locations:
 
 - **Subnet**: The Recall chain where all transactions and storage operations occur. Most commonly,
-  this what developers will interact with.
+  this is what developers will interact with.
 - **Parent**: The "rootnet" chain for managing Recall subnets, validators, checkpointing state, and
   other core protocol operations. For example, the Recall testnet's parent chain is the Filecoin
   Calibration testnet.

--- a/docs/sources/privacy.mdx
+++ b/docs/sources/privacy.mdx
@@ -20,9 +20,9 @@ where you may want to keep data private include:
 
 ## Data visibility
 
-If you choose to encrypt your data, other can "see" its existence but will be unable to read its
+If you choose to encrypt your data, others can "see" its existence but will be unable to read its
 contents without the proper decryption key. That is, unless you provision access through your
-encryption tooling, the data will not readable by others.
+encryption tooling, the data will not be readable by others.
 
 But, since Recall is a blockchain, certain data will _always_ be visible, including:
 

--- a/docs/tools/s3/index.mdx
+++ b/docs/tools/s3/index.mdx
@@ -70,7 +70,7 @@ Note that if you didn't install the binary in the previous step, you can run it 
 <Callout type="info">
 
 If you do not already have a private key, you can generate one with the Recall CLI. You also _must_
-make sure your account exists on the subnet, which requires you have deposited funds into your
+make sure your account exists on the subnet, which requires you to have deposited funds into your
 subnet account. Neglecting this step will lead to errors like
 `failed to init sequence; actor ... cannot be found`.
 

--- a/docs/tools/sdk/index.mdx
+++ b/docs/tools/sdk/index.mdx
@@ -24,5 +24,5 @@ support over time:
 </Cards>
 
 The Rust SDK provides the greatest API surface area since it has access to the same libraries in
-which the core Recall protocol is written in. The TypeScript SDK is a lighter weight SDK that is
+which the core Recall protocol is written. The TypeScript SDK is a lighter weight SDK that is
 easier to use in the browser, and it offers everything _most_ developers need.

--- a/docs/tools/sdk/rust/examples.mdx
+++ b/docs/tools/sdk/rust/examples.mdx
@@ -4,7 +4,7 @@ description: A series of Recall SDK examples.
 ---
 
 The Recall SDK can be used to interact with both accounts and the actual bucket layer. This page
-outlines a handful of example for different use cases.
+outlines a handful of examples for different use cases.
 
 ## Creating a new account
 

--- a/docs/tools/sdk/rust/usage.mdx
+++ b/docs/tools/sdk/rust/usage.mdx
@@ -9,7 +9,7 @@ started.
 
 ## Signer & provider setup
 
-To create an bucket, you'll need to use the `JsonRpcProvider` from the `recall_provider` crate plus
+To create a bucket, you'll need to use the `JsonRpcProvider` from the `recall_provider` crate plus
 various `recall_sdk` types.
 
 Here's a simple example. The `signer.init_sequence()` call is optional, but without it, you'll run


### PR DESCRIPTION
# Changes

fix typo

# Description

I've checked every 'md' and 'mdx' files in the repository and fixed typos that altered the meaning. Some wording and punctuation were slightly awkward, but I left them as they didn't affect comprehension.

The commit message briefly explains the typo corrections and why they were necessary. Hope this helps.