### PR TITLE
chore: update chain.love testnet urls

### DIFF
--- a/docs/protocol/contracts/index.mdx
+++ b/docs/protocol/contracts/index.mdx
@@ -42,9 +42,9 @@ Calibration), and only one child subnet exists, defined by the subnet actor cont
 
 | Description    | Value                                         |
 | -------------- | --------------------------------------------- |
-| Recall EVM RPC | `https://evm.recall.chain.love`               |
-| Object API     | `https://objects.recall.chain.love`           |
-| CometBFT RPC   | `https://api.recall.chain.love`               |
+| Recall EVM RPC | `https://evm.testnet.recall.chain.love`               |
+| Object API     | `https://objects.testnet.recall.chain.love`           |
+| CometBFT RPC   | `https://api.testnet.recall.chain.love`               |
 | Parent EVM RPC | `https://api.calibration.node.glif.io/rpc/v1` |
 
 <Callout type="info">

--- a/docs/protocol/network/api-cometbft.mdx
+++ b/docs/protocol/network/api-cometbft.mdx
@@ -11,7 +11,7 @@ to CometBFT before being sent to the Wasm/EVM runtime.
 
 The CometBFT API endpoints for each of the Recall chain environments are listed below:
 
-- `testnet`: `https://api.recall.chain.love`
+- `testnet`: `https://api.testnet.recall.chain.love`
 - `localnet` or `devnet`: `http://127.0.0.1:26657`
 
 ## Endpoints

--- a/docs/protocol/network/api-evm.mdx
+++ b/docs/protocol/network/api-evm.mdx
@@ -18,7 +18,7 @@ currently are not supported. Instead, use the Paris EVM version.
 
 The EVM API endpoints for each of the Recall chain environments are listed below:
 
-- `testnet`: `https://evm.recall.chain.love`
+- `testnet`: `https://evm.testnet.recall.chain.love`
 - `localnet` or `devnet`: `http://127.0.0.1:8645`
 
 The parent chain RPCs for Recall are the following. These are only relevant if you're working with

--- a/docs/protocol/network/api-object.mdx
+++ b/docs/protocol/network/api-object.mdx
@@ -12,7 +12,7 @@ signed data to the Recall network.
 
 The object API endpoints for each of the Recall chain environments are listed below:
 
-- `testnet`: `https://objects.recall.chain.love`
+- `testnet`: `https://objects.testnet.recall.chain.love`
 - `localnet` or `devnet`: `http://127.0.0.1:8001`
 
 ## Endpoints


### PR DESCRIPTION
@dtbuchholz is there some place we can mention the read-only S3 endpoint, `s3.testnet.recall.chain.love`? 