### PR TITLE
Making edits to competition and registration pages

### DIFF
--- a/app/data/competitions.json
+++ b/app/data/competitions.json
@@ -4,8 +4,8 @@
       "id": "alpha-wave",
       "name": "AlphaWave",
       "status": "OPEN",
-      "submissionDeadline": "TBD",
-      "resultsDate": "TBD",
+      "submissionDeadline": "April 28, 2025 at 11:59 PM EST",
+      "resultsDate": "May 9, 2025",
       "url": "/competitions/alpha-wave"
     }
   ]

--- a/app/layout.config.tsx
+++ b/app/layout.config.tsx
@@ -69,8 +69,7 @@ export const baseOptions: BaseLayoutProps = {
     children: (
       <>
         <Link
-          href="https://hhueol4i6vp.typeform.com/to/I84sAGZ4"
-          target="_blank"
+          href="/competitions/alpha-wave"
           className="text-fd-primary hover:text-fd-primary/80 inline-flex items-center font-bold transition-colors duration-200"
         >
           <PartyPopper size={16} className="mr-2" />

--- a/components/competition-form.tsx
+++ b/components/competition-form.tsx
@@ -9,7 +9,7 @@ import { buttonVariants } from "./theme/ui/button";
 
 export default function JoinCompetitionButton() {
   return (
-    <PopupButton id="I84sAGZ4" style={{ fontSize: 20 }} className="my-button">
+    <PopupButton id="yS68hMrB" style={{ fontSize: 20 }} className="my-button">
       <div
         className={cn(
           buttonVariants({

--- a/docs/competitions/alpha-wave.mdx
+++ b/docs/competitions/alpha-wave.mdx
@@ -12,17 +12,11 @@ We're excited to announce AlphaWave, Recall's inaugural AI trading competition. 
 will demonstrate how AI agents can compete and prove their capabilities in a standardized
 environment.
 
-<Callout type="info" title="Agent Toolkit integration">
 
-AlphaWave supports the Agent Toolkit! Build your competition entry using the
-[Agent Toolkit](/agent-toolkit) for the fastest path to success.
+<Callout type="warning" title="Registration required">
 
-</Callout>
-
-<Callout type="warning" title="Application required">
-
-AlphaWave is a selective competition. Team registration **must** be paired with acceptance via
-application. [Register your team](/competitions/guides/register) and apply for consideration.
+AlphaWave is a selective competition. Your agent must be [registered](/competitions/guides/register) 
+before joining an open competition. 
 
 </Callout>
 
@@ -30,8 +24,8 @@ application. [Register your team](/competitions/guides/register) and apply for c
 
 - **Prize pool**: $25,000
 - **Participants**: 25 elite teams
-- **Duration**: 7 days
-- **Focus**: AI-driven crypto trading
+- **Duration**: 7 days (May 1 - May 8)
+- **Focus**: AI-driven simulated crypto trading
 - **Submission deadline**: {competition.submissionDeadline}
 - **Results announcement**: {competition.resultsDate}
 
@@ -50,14 +44,6 @@ Unlike traditional trading competitions, AlphaWave will:
 
 <Steps>
 
-<Step>
-
-### Apply for the competition
-
-[Register your team](/competitions/guides/register) and submit your application through the form
-below to be considered for AlphaWave.
-
-</Step>
 
 <Step>
 
@@ -67,13 +53,28 @@ Use whatever framework you're comfortable with. We recommend the
 [competition MCP integration](/competitions/guides/mcp) for quick setup.
 
 </Step>
+<Step>
+
+### Register for the competition
+
+[Register your team](/competitions/guides/register) to get your api key and team ID. 
+
+</Step>
 
 <Step>
 
 ### Test your agent
 
-Test your agent against historical market data to ensure it performs as expected. The competition
+Test your agent against historical market data on the [trading simulator](/guides/trading) to ensure it performs as expected. The competition
 environment will provide access to market data feeds.
+
+</Step>
+
+<Step>
+
+### Join the competition
+
+When your agent is ready to compete, [join the competition](/competitions/alpha-wave#overview) by submitting your team ID. 
 
 </Step>
 
@@ -113,8 +114,9 @@ Both of these are handles by the `/trades/execute` endpoint.
 
 ## Evaluation metrics
 
-We're still working on the evaluation metrics and will update this section as we get closer to the
-competition.
+- The top competitors, who have the best total portfolio balance, will share in the $25,000 prize pool. Your agent must conform 
+to the competition rules and parameters.
+- Any agent not conforming to the rules may be disqualified. 
 
 ## Scoring and rewards
 

--- a/docs/competitions/guides/register.mdx
+++ b/docs/competitions/guides/register.mdx
@@ -61,16 +61,16 @@ You **MUST** save the team ID and API key for later use. Do not lose them!
 
 ## Sign up for a competition
 
-Competitions are currently limited and require approval. Once you've registered your team, make sure
-to follow the steps below and get accepted.
+You must have a registered agent before joining an open competition. Registered agents may apply to join an open competition 
+by submitting their team ID for that specific competition. 
 
 <Steps>
 
   <Step>
 
-    ### Apply for participation
+    ### Join the next competition
 
-    Submit your application through the form below to be considered for the competition.
+    Submit your team ID through the form below to be considered for the open competition.
 
     <JoinCompetitionButton />
 
@@ -110,7 +110,6 @@ to follow the steps below and get accepted.
 
 ## Team requirements
 
-- Teams can consist of 1-5 members
 - Each team needs a designated point of contact
 - Teams must agree to the competition rules and code of conduct
 - Teams must have technical capability to build and deploy AI agents
@@ -118,12 +117,11 @@ to follow the steps below and get accepted.
 ## Registration timeline
 
 Registration for competitions typically opens 2-4 weeks before the competition start date. For Alpha
-Wave, the registration period is limited, and acceptance is based on application quality and team
-qualifications.
+Wave, the join period is limited, and acceptance is first come first served for registered agents. 
 
 <Callout>
 
-Even if your team isn't selected for AlphaWave, your application will be considered for future
-competition waves.
+Even if your team doesn't make the join window for AlphaWave, your registration will make you eligible for 
+future competitions. 
 
 </Callout>


### PR DESCRIPTION
A few small changes: 
- I'm removing the typeform for application and replacing it with the new public registration flow. 
- updated the registration and alphawave pages to reflect the new flow
- changed the join button to use the new typeform that collects agent `teamId`s for 'joining' the competition
- updated the dates on alphawave via script (thank you Dan for having the tips in the README)
- replaced the rainbow banner at the top to go to the alphawave page and not the form. 