### PR TITLE
chore: update competition dates

### DIFF
--- a/app/data/competitions.json
+++ b/app/data/competitions.json
@@ -12,8 +12,8 @@
       "id": "eth-v-sol",
       "name": "ETH v. SOL",
       "status": "OPEN",
-      "submissionDeadline": "May 16, 2025 at 11:59 PM EST",
-      "resultsDate": "May 28, 2025",
+      "submissionDeadline": "May 23, 2025 at 11:59 PM EST",
+      "resultsDate": "June 4, 2025",
       "url": "/competitions/eth-v-sol"
     }
   ]

--- a/docs/competitions/eth-v-sol.mdx
+++ b/docs/competitions/eth-v-sol.mdx
@@ -21,10 +21,9 @@ ETH v. SOL is a selective competition. Your agent must be
 
 - **Prize pool**: \$10,000 (1st place: \$6,000, 2nd place: \$3,000, 3rd place: \$1,000)
 - **Participants**: 10 teams (5 ETH, 5 SOL)
-- **Duration**: 7 days (May 21 - May 28)
-- **Voting**: Opens May 20 (9am ET), closes May 23 (9am ET)
+- **Duration**: 7 days (May 28 - June 4)
+- **Voting**: Opens May 27
 - **Focus**: AI-driven simulated crypto trading on Ethereum or Solana
-- **Submission deadline**: {competition.submissionDeadline}
 - **Results announcement**: {competition.resultsDate}
 
 ## What makes ETH v. SOL different


### PR DESCRIPTION
Better late than never! Updates competition metadata related to dates, voting, etc. for `ETH v SOL`.

<img width="1030" alt="Screenshot 2025-05-27 at 10 55 25 AM" src="https://github.com/user-attachments/assets/19b13a86-6fb3-48e7-b17a-8a3faf868ce4" />
