### PR TITLE
feat: update quickstart to competitions

### DIFF
--- a/docs/agent-toolkit/meta.json
+++ b/docs/agent-toolkit/meta.json
@@ -2,6 +2,7 @@
   "title": "Agent Toolkit",
   "pages": [
     "installation",
+    "quickstart",
     "core-concepts",
     "tools-reference",
     "authentication",

--- a/docs/agent-toolkit/quickstart.mdx
+++ b/docs/agent-toolkit/quickstart.mdx
@@ -1,0 +1,534 @@
+---
+title: Quickstart
+description: Build your first Recall agent in 15 minutes
+---
+
+This quickstart guide will help you build a simple agent that can interact with the Recall network
+using the [Agent Toolkit](/agent-toolkit) and [MCP integration](/mcp).
+
+<Callout type="warning" title="Agent setup & storage requirements">
+
+All Recall operations require tokens and credits. Before getting started, you'll need to:
+
+1. Create an account with the [CLI](/tools/cli/account#create-an-account), or use an existing EVM
+   wallet (e.g., export from MetaMask).
+2. Get tokens from the [Recall Faucet](https://faucet.recall.network) for your wallet address.
+3. Purchase credit for your account with the [Recall Portal](https://portal.recall.network) or the
+   [CLI](/tools/cli/account#buy-credit).
+
+</Callout>
+
+<Callout type="info">
+
+This guide assumes you have basic Node.js and TypeScript knowledge. If you need a primer, check out
+the [Node.js documentation](https://nodejs.org/en/docs/) and
+[TypeScript documentation](https://www.typescriptlang.org/docs/).
+
+</Callout>
+
+## Prerequisites
+
+- Node.js 20 or later
+- `npm`, `yarn`, or `pnpm`
+- A code editor (Cursor, VS Code, or your favorite IDE)
+- Recall testnet tokens (we'll get these in Step 1)
+
+<Steps>
+
+<Step>
+
+## Set up your Recall account
+
+### Get testnet tokens from the faucet
+
+Before you can use Recall, you need testnet tokens:
+
+1. Visit the [Recall Faucet](https://faucet.recall.network)
+2. Enter your wallet address
+3. Complete the verification and click "Request RECALL"
+4. Wait for the transaction to complete
+
+<Callout type="info">
+
+The faucet sends 5 RECALL tokens to your wallet.
+
+</Callout>
+
+### Convert tokens to credits
+
+Recall data storage features require credits, not just tokens:
+
+<Tabs items={["Portal (Web UI)", "Agent Toolkit", "SDK"]}>
+  <Tab>
+
+    1. Visit the [Recall Portal](https://portal.recall.network)
+    2. Connect your wallet
+    3. Navigate to the "Credit" tab
+    4. Click "Buy Credits" and enter the amount
+    5. Confirm the transaction in your wallet
+
+  </Tab>
+  <Tab>
+
+    ```typescript
+    import { RecallAgentToolkit } from "@recallnet/agent-toolkit/langchain";
+
+    // Later in your code
+    // This is available if you set account.write: true in your configuration
+    // Find the buy_credit tool and call it with the appropriate parameters
+    const buyTool = toolkit.getTools().find(tool => tool.name === "buy_credit");
+    const result = await buyTool.invoke({
+      amount: "1" // Convert 1 RECALL to credits
+    });
+    console.log("Credit purchase result:", result);
+    ```
+
+  </Tab>
+  <Tab>
+
+    ```typescript
+    import {
+      RecallClient,
+      walletClientFromPrivateKey,
+    } from "@recallnet/sdk/client";
+    import { testnet } from "@recallnet/chains";
+    import { parseEther } from "viem";
+
+    const walletClient = walletClientFromPrivateKey(
+      "0xyour_private_key_here",
+      testnet
+    );
+    const client = new RecallClient({
+      walletClient,
+    });
+    const creditManager = client.creditManager();
+    const amount = parseEther("1"); // 1 RECALL token
+    const { meta } = await creditManager.buy(amount);
+    console.log("Credit purchase transaction:", meta?.tx?.transactionHash);
+    ```
+
+  </Tab>
+
+</Tabs>
+
+<Callout type="warning">
+  Without credits, your agent won't be able to store data. Make sure to convert some tokens to
+  credits before proceeding.
+</Callout>
+
+</Step>
+
+<Step>
+
+## Create a new project
+
+### Set up a project directory
+
+```bash
+mkdir my-recall-agent && cd my-recall-agent
+```
+
+### Initialize & install dependencies
+
+<Tabs groupId="package-install" items={["npm", "pnpm", "yarn", "bun"]}>
+<Tab>
+
+```sh
+npm init -y
+```
+
+</Tab>
+<Tab>
+
+```sh
+pnpm init
+```
+
+</Tab>
+<Tab>
+
+```sh
+yarn init -y
+```
+
+</Tab>
+<Tab>
+
+```sh
+bun init
+```
+
+</Tab>
+</Tabs>
+
+Install the development dependencies:
+
+```package-install
+npm install -D typescript tsc tsx @types/node
+```
+
+Initialize the TypeScript project:
+
+<Tabs groupId="package-install" items={["npm", "pnpm", "yarn", "bun"]}>
+<Tab>
+
+```sh
+npm tsc --init
+```
+
+</Tab>
+<Tab>
+
+```sh
+pnpm tsc --init
+```
+
+</Tab>
+<Tab>
+
+```sh
+yarn tsc --init
+```
+
+</Tab>
+<Tab>
+
+```sh
+bun tsc --init
+```
+
+</Tab>
+</Tabs>
+
+Install the Agent Toolkit and core dependencies:
+
+```package-install
+npm install @recallnet/agent-toolkit @modelcontextprotocol/sdk dotenv
+```
+
+Lastly, create an `src/agent.ts` file in your project root:
+
+```bash
+mkdir -p src && touch src/agent.ts
+```
+
+### Update your configuration files
+
+First, update your `package.json` file to include the following—the key callout is the `type` field,
+which should be set to `module`. We'll also add some helper scripts to run the agent as a TypeScript
+file, or build and run the agent as a compiled JavaScript file.
+
+```json title="package.json"
+{
+  "name": "recall-agent",
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/agent.ts",
+    "build": "tsc",
+    "start": "node dist/agent.js"
+  }
+  // `dependencies` and `devDependencies` below
+}
+```
+
+Then, update your `tsconfig.json` file with the following:
+
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/agent.ts"],
+  "exclude": ["node_modules", "dist"]
+}
+```
+
+### Create an environment file
+
+Create a `.env` file in your project root:
+
+```bash
+touch .env
+```
+
+Add your private key to the `.env` file, the Recall network, and your
+[OpenAI API key](https://platform.openai.com/api-keys):
+
+```
+# Your Recall private key (with 0x prefix)
+RECALL_PRIVATE_KEY=0xyour_private_key_here
+
+# Network to connect to (testnet or localnet)
+RECALL_NETWORK=testnet
+
+# Your OpenAI API key
+OPENAI_API_KEY=your_openai_api_key_here
+```
+
+<Callout type="warning">
+  Never share your private key or commit it to version control. Consider using `.gitignore` to
+  exclude the `.env` file.
+</Callout>
+
+</Step>
+
+<Step>
+
+## Build a programmable agent
+
+We'll build a simple LangChain agent that can create and manage buckets in Recall.
+
+### Install LangChain dependencies
+
+```package-install
+npm install @langchain/openai @langchain/core langchain
+```
+
+### Create an agent file
+
+Now let's update our `src/agent.ts` file to programmatically create an agent that can use Recall's
+tools. We'll start by setting up the following:
+
+- Import our environment variables
+- Initialize the language model
+- Create the Recall toolkit with configuration
+- Get LangChain-compatible tools
+- Create a prompt template for the agent
+
+```typescript title="src/agent.ts"
+import {
+  ChatPromptTemplate,
+  HumanMessagePromptTemplate,
+  MessagesPlaceholder,
+  SystemMessagePromptTemplate,
+} from "@langchain/core/prompts";
+import { ChatOpenAI } from "@langchain/openai";
+import { RecallAgentToolkit } from "@recallnet/agent-toolkit/langchain";
+import * as dotenv from "dotenv";
+import { AgentExecutor, createOpenAIFunctionsAgent } from "langchain/agents";
+
+// Load environment variables
+dotenv.config();
+
+const { RECALL_PRIVATE_KEY, RECALL_NETWORK, OPENAI_API_KEY } = process.env;
+if (!RECALL_PRIVATE_KEY || !OPENAI_API_KEY) {
+  throw new Error(`Missing required environment variables: RECALL_PRIVATE_KEY and OPENAI_API_KEY`);
+}
+
+// Initialize the language model
+const llm = new ChatOpenAI({
+  model: "gpt-4o",
+  apiKey: OPENAI_API_KEY,
+  temperature: 0.7,
+});
+
+// Create the Recall toolkit with configuration
+const recallToolkit = new RecallAgentToolkit({
+  privateKey: RECALL_PRIVATE_KEY,
+  configuration: {
+    actions: {
+      account: {
+        read: true,
+        write: true,
+      },
+      bucket: {
+        read: true,
+        write: true,
+      },
+    },
+    context: {
+      network: RECALL_NETWORK || "testnet",
+    },
+  },
+});
+
+// Get LangChain-compatible tools
+const tools = recallToolkit.getTools();
+
+// Create a prompt template for the agent
+const prompt = ChatPromptTemplate.fromMessages([
+  SystemMessagePromptTemplate.fromTemplate(
+    "You are a helpful assistant with access to Recall storage capabilities. " +
+      "1. You can create and manage storage buckets\n" +
+      "2. You can store and retrieve information in buckets\n" +
+      "3. You can handle both text and binary data\n"
+  ),
+  new MessagesPlaceholder("agent_scratchpad"),
+  HumanMessagePromptTemplate.fromTemplate("{input}"),
+]);
+```
+
+Now, let's create a `main()` function to run the agent. This function will:
+
+- Create the agent
+- Create the executor
+- Define a task for the agent (specific to Recall)
+- Have the agent actions execute these actions
+
+```typescript title="src/agent.ts"
+// Existing code...
+
+async function main() {
+  try {
+    // Create the agent
+    const agent = await createOpenAIFunctionsAgent({
+      llm,
+      tools,
+      prompt,
+    });
+
+    // Create the executor
+    const agentExecutor = new AgentExecutor({
+      agent,
+      tools,
+    });
+
+    // Define a task for the agent
+    const task =
+      "Create a bucket called 'memories', store a note with the key 'first-memory' and content 'This is my first memory', then retrieve that memory and summarize what you did.";
+
+    console.log("Running the agent...");
+    console.log("Task:", task);
+    console.log("---------------------------------------------");
+
+    // Run the agent
+    const response = await agentExecutor.invoke({
+      input: task,
+    });
+
+    // Display the result
+    console.log("\nAgent response:");
+    console.log(response.output);
+  } catch (error) {
+    console.error("Error running agent:", error);
+  }
+}
+
+main();
+```
+
+### Run your agent
+
+Run the agent using your preferred package manager:
+
+<Tabs groupId="package-install" items={["npm", "pnpm", "yarn", "bun"]}>
+  <Tab>
+
+    ```bash
+    npm run dev
+    ```
+
+  </Tab>
+  <Tab>
+
+    ```bash
+    pnpm run dev
+    ```
+
+  </Tab>
+  <Tab>
+
+    ```bash
+    yarn run dev
+    ```
+
+  </Tab>
+  <Tab>
+
+    ```bash
+    bun run dev
+    ```
+
+  </Tab>
+</Tabs>
+
+This should output something like the following:
+
+```
+Running the agent...
+Task: Create a bucket called 'memories', store a note with the key 'first-memory' and
+content 'This is my first memory', then retrieve that memory and summarize what you did.
+---------------------------------------------
+
+Agent response:
+I created a bucket with the alias "memories" and stored a note with the key "first-memory"
+containing the text "This is my first memory." After storing it, I retrieved the memory,
+which confirmed the content as expected.
+```
+
+<Callout type="info">
+  You can also run the agent using the `build` and `start` scripts to run the compiled JavaScript
+  file with Node.
+</Callout>
+
+</Step>
+
+<Step>
+
+## Optional: Configure MCP clients
+
+Optionally, you can set up the Recall MCP server and use it with any MCP-compatible client. This is
+useful if you want your agent to interact through Recall purely through MCP, as opposed to the
+programmatic Agent Toolkit example below. Some popular options include:
+
+- [Cursor](https://cursor.sh/)
+- [Claude Desktop](https://claude.ai/)
+
+<Callout type="info">
+  The MCP clients will automatically start the Recall MCP server using the configuration provided
+  below. You don't need to run the server separately.
+</Callout>
+
+#### Cursor configuration
+
+1. In Cursor, go to _Settings > Cursor Settings > MCP_
+2. Click "Add New Global MCP Server"
+3. Add the following configuration:
+
+```json
+{
+  "mcpServers": {
+    "recall-mcp": {
+      "name": "Recall MCP",
+      "type": "command",
+      "command": "npx",
+      "args": ["-y", "@recallnet/mcp"],
+      "env": {
+        "RECALL_PRIVATE_KEY": "0xyour_private_key_here",
+        "RECALL_NETWORK": "testnet"
+      }
+    }
+  }
+}
+```
+
+4. Save the file and restart Cursor
+
+#### Claude Desktop configuration
+
+1. Locate your Claude Desktop configuration file at:
+
+   - macOS: `~/Library/Application\ Support/Claude/claude_desktop_config.json`
+   - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+   - Linux: `~/.config/Claude/claude_desktop_config.json`
+
+2. Add the same configuration as above.
+3. Save the file and restart Claude Desktop
+
+<Callout type="info">
+  Once set up, you can ask the agent to create a bucket, store some data, and retrieve it on Recall.
+</Callout>
+
+</Step>
+
+</Steps>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -81,15 +81,16 @@ url = "https://api.competitions.recall.network/sandbox/api/trade/execute"
 
 # Example trade payload
 trade_data = {
-    "fromToken": "So11111111111111111111111111111112",
-    "toToken": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-    "amount": "1.5",
-    "reason": "Strong upward momentum in the market combined with positive news on this token's ecosystem growth.",
-    "slippageTolerance": "0.5",
-    "fromChain": "svm",
-    "fromSpecificChain": "mainnet",
-    "toChain": "svm",
-    "toSpecificChain": "mainnet"
+    "fromToken": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    "toToken": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+    "amount": "100",
+    "reason": "Trading 100 USDC to Weth Eth Mainnet to verify my Recall developer account"
+    # These parameters are optional. Our server infers most things from the token addresses.
+    # "slippageTolerance": "0.5",
+    # "fromChain": "evm",
+    # "fromSpecificChain": "mainnet",
+    # "toChain": "evm",
+    # "toSpecificChain": "mainnet"
 }
 
 # Headers with your API key

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,558 +1,131 @@
 ---
 title: Quickstart
-description: Build your first Recall agent in 15 minutes
+description: Build your first AI agent trading competition bot in minutes
 ---
 
-This quickstart guide will help you build a simple agent that can interact with the Recall network
-using the [Agent Toolkit](/agent-toolkit) and [MCP integration](/mcp). By the end of this guide,
-you'll have a working agent that you can submit to competitions.
-
-<Callout type="warning" title="Agent setup & storage requirements">
-
-All Recall operations require tokens and credits. Before getting started, you'll need to:
-
-1. Create an account with the [CLI](/tools/cli/account#create-an-account), or use an existing EVM
-   wallet (e.g., export from MetaMask).
-2. Get tokens from the [Recall Faucet](https://faucet.recall.network) for your wallet address.
-3. Purchase credit for your account with the [Recall Portal](https://portal.recall.network) or the
-   [CLI](/tools/cli/account#buy-credit).
-
-</Callout>
+Recall is an AI agent competition platform where developers can build and test automated crypto
+trading strategies in simulated environments. This quickstart guide will help you register a new
+trading agent and make your first practice trade with our API.
 
 <Callout type="info">
 
-This guide assumes you have basic Node.js and TypeScript knowledge. If you need a primer, check out
-the [Node.js documentation](https://nodejs.org/en/docs/) and
-[TypeScript documentation](https://www.typescriptlang.org/docs/).
+This guide assumes you have basic programming knowledge and familiarity with REST APIs. If you need
+help with Python or API integration, check out the [Python documentation](https://docs.python.org/)
+or [Requests library documentation](https://requests.readthedocs.io/).
 
 </Callout>
 
 ## Prerequisites
 
-- Node.js 20 or later
-- `npm`, `yarn`, or `pnpm`
+- [Python 3](https://www.python.org/downloads/) (or your preferred programming language)
 - A code editor (Cursor, VS Code, or your favorite IDE)
-- Recall testnet tokens (we'll get these in Step 1)
+- A very basic understanding of crypto markets and trading concepts
 
 <Steps>
 
 <Step>
 
-## Set up your Recall account
+## Register for API access
 
-### Get testnet tokens from the faucet
+Before you can build and test trading agents, you need to register for API access:
 
-Before you can use Recall, you need testnet tokens:
-
-1. Visit the [Recall Faucet](https://faucet.recall.network)
-2. Enter your wallet address
-3. Complete the verification and click "Request RECALL"
-4. Wait for the transaction to complete
-
-<Callout type="info">
-
-The faucet sends 5 RECALL tokens to your wallet.
-
-</Callout>
-
-### Convert tokens to credits
-
-Competitions and storage features require credits, not just tokens:
-
-<Tabs items={["Portal (Web UI)", "Agent Toolkit", "SDK"]}>
-  <Tab>
-
-    1. Visit the [Recall Portal](https://portal.recall.network)
-    2. Connect your wallet
-    3. Navigate to the "Credit" tab
-    4. Click "Buy Credits" and enter the amount
-    5. Confirm the transaction in your wallet
-
-  </Tab>
-  <Tab>
-
-    ```typescript
-    import { RecallAgentToolkit } from "@recallnet/agent-toolkit/langchain";
-
-    // Later in your code
-    // This is available if you set account.write: true in your configuration
-    // Find the buy_credit tool and call it with the appropriate parameters
-    const buyTool = toolkit.getTools().find(tool => tool.name === "buy_credit");
-    const result = await buyTool.invoke({
-      amount: "1" // Convert 1 RECALL to credits
-    });
-    console.log("Credit purchase result:", result);
-    ```
-
-  </Tab>
-  <Tab>
-
-    ```typescript
-    import {
-      RecallClient,
-      walletClientFromPrivateKey,
-    } from "@recallnet/sdk/client";
-    import { testnet } from "@recallnet/chains";
-    import { parseEther } from "viem";
-
-    const walletClient = walletClientFromPrivateKey(
-      "0xyour_private_key_here",
-      testnet
-    );
-    const client = new RecallClient({
-      walletClient,
-    });
-    const creditManager = client.creditManager();
-    const amount = parseEther("1"); // 1 RECALL token
-    const { meta } = await creditManager.buy(amount);
-    console.log("Credit purchase transaction:", meta?.tx?.transactionHash);
-    ```
-
-  </Tab>
-
-</Tabs>
+- Visit [register.recall.network](http://register.recall.network/)
+- Create your account
+- Receive your API key for authentication
 
 <Callout type="warning">
-  Without credits, your agent won't be able to store data or participate in competitions. Make sure
-  to convert some tokens to credits before proceeding.
+
+Keep your API key secure and never share it publicly. You'll need this key to authenticate your
+agent when making trades and accessing competition data.
+
 </Callout>
 
 </Step>
 
 <Step>
 
-## Create a new project
-
-### Set up a project directory
-
-```bash
-mkdir my-recall-agent && cd my-recall-agent
-```
-
-### Initialize & install dependencies
-
-<Tabs groupId="package-install" items={["npm", "pnpm", "yarn", "bun"]}>
-<Tab>
-
-```sh
-npm init -y
-```
-
-</Tab>
-<Tab>
-
-```sh
-pnpm init
-```
-
-</Tab>
-<Tab>
-
-```sh
-yarn init -y
-```
-
-</Tab>
-<Tab>
-
-```sh
-bun init
-```
-
-</Tab>
-</Tabs>
-
-Install the development dependencies:
-
-```package-install
-npm install -D typescript tsc tsx @types/node
-```
-
-Initialize the TypeScript project:
-
-<Tabs groupId="package-install" items={["npm", "pnpm", "yarn", "bun"]}>
-<Tab>
-
-```sh
-npm tsc --init
-```
-
-</Tab>
-<Tab>
-
-```sh
-pnpm tsc --init
-```
-
-</Tab>
-<Tab>
-
-```sh
-yarn tsc --init
-```
-
-</Tab>
-<Tab>
-
-```sh
-bun tsc --init
-```
-
-</Tab>
-</Tabs>
-
-Install the Agent Toolkit and core dependencies:
-
-```package-install
-npm install @recallnet/agent-toolkit @modelcontextprotocol/sdk dotenv
-```
-
-Lastly, create an `src/agent.ts` file in your project root:
-
-```bash
-mkdir -p src && touch src/agent.ts
-```
-
-### Update your configuration files
-
-First, update your `package.json` file to include the following—the key callout is the `type` field,
-which should be set to `module`. We'll also add some helper scripts to run the agent as a TypeScript
-file, or build and run the agent as a compiled JavaScript file.
-
-```json title="package.json"
-{
-  "name": "recall-agent",
-  "version": "0.0.0",
-  "type": "module",
-  "scripts": {
-    "dev": "tsx src/agent.ts",
-    "build": "tsc",
-    "start": "node dist/agent.js"
-  }
-  // `dependencies` and `devDependencies` below
-}
-```
-
-Then, update your `tsconfig.json` file with the following:
-
-```json title="tsconfig.json"
-{
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "strict": true,
-    "skipLibCheck": true,
-    "resolveJsonModule": true,
-    "outDir": "dist",
-    "declaration": true,
-    "sourceMap": true
-  },
-  "include": ["src/agent.ts"],
-  "exclude": ["node_modules", "dist"]
-}
-```
-
-### Create an environment file
-
-Create a `.env` file in your project root:
-
-```bash
-touch .env
-```
-
-Add your private key to the `.env` file, the Recall network, and your
-[OpenAI API key](https://platform.openai.com/api-keys):
-
-```
-# Your Recall private key (with 0x prefix)
-RECALL_PRIVATE_KEY=0xyour_private_key_here
-
-# Network to connect to (testnet or localnet)
-RECALL_NETWORK=testnet
-
-# Your OpenAI API key
-OPENAI_API_KEY=your_openai_api_key_here
-```
-
-<Callout type="warning">
-  Never share your private key or commit it to version control. Consider using `.gitignore` to
-  exclude the `.env` file.
-</Callout>
-
-</Step>
-
-<Step>
-
-## Build a programmable agent
-
-We'll build a simple LangChain agent that can create and manage buckets in Recall.
-
-### Install LangChain dependencies
-
-```package-install
-npm install @langchain/openai @langchain/core langchain
-```
-
-### Create an agent file
-
-Now let's update our `src/agent.ts` file to programmatically create an agent that can use Recall's
-tools. We'll start by setting up the following:
-
-- Import our environment variables
-- Initialize the language model
-- Create the Recall toolkit with configuration
-- Get LangChain-compatible tools
-- Create a prompt template for the agent
-
-```typescript title="src/agent.ts"
-import {
-  ChatPromptTemplate,
-  HumanMessagePromptTemplate,
-  MessagesPlaceholder,
-  SystemMessagePromptTemplate,
-} from "@langchain/core/prompts";
-import { ChatOpenAI } from "@langchain/openai";
-import { RecallAgentToolkit } from "@recallnet/agent-toolkit/langchain";
-import * as dotenv from "dotenv";
-import { AgentExecutor, createOpenAIFunctionsAgent } from "langchain/agents";
-
-// Load environment variables
-dotenv.config();
-
-const { RECALL_PRIVATE_KEY, RECALL_NETWORK, OPENAI_API_KEY } = process.env;
-if (!RECALL_PRIVATE_KEY || !OPENAI_API_KEY) {
-  throw new Error(`Missing required environment variables: RECALL_PRIVATE_KEY and OPENAI_API_KEY`);
-}
-
-// Initialize the language model
-const llm = new ChatOpenAI({
-  model: "gpt-4o",
-  apiKey: OPENAI_API_KEY,
-  temperature: 0.7,
-});
-
-// Create the Recall toolkit with configuration
-const recallToolkit = new RecallAgentToolkit({
-  privateKey: RECALL_PRIVATE_KEY,
-  configuration: {
-    actions: {
-      account: {
-        read: true,
-        write: true,
-      },
-      bucket: {
-        read: true,
-        write: true,
-      },
-    },
-    context: {
-      network: RECALL_NETWORK || "testnet",
-    },
-  },
-});
-
-// Get LangChain-compatible tools
-const tools = recallToolkit.getTools();
-
-// Create a prompt template for the agent
-const prompt = ChatPromptTemplate.fromMessages([
-  SystemMessagePromptTemplate.fromTemplate(
-    "You are a helpful assistant with access to Recall storage capabilities. " +
-      "1. You can create and manage storage buckets\n" +
-      "2. You can store and retrieve information in buckets\n" +
-      "3. You can handle both text and binary data\n"
-  ),
-  new MessagesPlaceholder("agent_scratchpad"),
-  HumanMessagePromptTemplate.fromTemplate("{input}"),
-]);
-```
-
-Now, let's create a `main()` function to run the agent. This function will:
-
-- Create the agent
-- Create the executor
-- Define a task for the agent (specific to Recall)
-- Have the agent actions execute these actions
-
-```typescript title="src/agent.ts"
-// Existing code...
-
-async function main() {
-  try {
-    // Create the agent
-    const agent = await createOpenAIFunctionsAgent({
-      llm,
-      tools,
-      prompt,
-    });
-
-    // Create the executor
-    const agentExecutor = new AgentExecutor({
-      agent,
-      tools,
-    });
-
-    // Define a task for the agent
-    const task =
-      "Create a bucket called 'memories', store a note with the key 'first-memory' and content 'This is my first memory', then retrieve that memory and summarize what you did.";
-
-    console.log("Running the agent...");
-    console.log("Task:", task);
-    console.log("---------------------------------------------");
-
-    // Run the agent
-    const response = await agentExecutor.invoke({
-      input: task,
-    });
-
-    // Display the result
-    console.log("\nAgent response:");
-    console.log(response.output);
-  } catch (error) {
-    console.error("Error running agent:", error);
-  }
-}
-
-main();
-```
-
-### Run your agent
-
-Run the agent using your preferred package manager:
-
-<Tabs groupId="package-install" items={["npm", "pnpm", "yarn", "bun"]}>
-  <Tab>
-
-    ```bash
-    npm run dev
-    ```
-
-  </Tab>
-  <Tab>
-
-    ```bash
-    pnpm run dev
-    ```
-
-  </Tab>
-  <Tab>
-
-    ```bash
-    yarn run dev
-    ```
-
-  </Tab>
-  <Tab>
-
-    ```bash
-    bun run dev
-    ```
-
-  </Tab>
-</Tabs>
-
-This should output something like the following:
-
-```
-Running the agent...
-Task: Create a bucket called 'memories', store a note with the key 'first-memory' and
-content 'This is my first memory', then retrieve that memory and summarize what you did.
----------------------------------------------
-
-Agent response:
-I created a bucket with the alias "memories" and stored a note with the key "first-memory"
-containing the text "This is my first memory." After storing it, I retrieved the memory,
-which confirmed the content as expected.
-```
+## Verify your agent by making a practice trade
+
+Before joining live competitions, you must verify that your agent works correctly by submitting at
+least one trade to the **sandbox competition**, our testing server that matches the production API.
+The sandbox runs continuously and is perfect for testing your strategy before a competition starts.
 
 <Callout type="info">
-  You can also run the agent using the `build` and `start` scripts to run the compiled JavaScript
-  file with Node.
+
+Our trading competitions API can be called with any programming language or framework you like. This
+section provides an example implementation in python.
+
 </Callout>
 
-</Step>
+### Install dependencies
 
-<Step>
+First, install the required dependencies for making API calls.
 
-## Optional: Configure MCP clients
-
-Optionally, you can set up the Recall MCP server and use it with any MCP-compatible client. This is
-useful if you want your agent to interact through Recall purely through MCP, as opposed to the
-programmatic Agent Toolkit example below. Some popular options include:
-
-- [Cursor](https://cursor.sh/)
-- [Claude Desktop](https://claude.ai/)
-
-<Callout type="info">
-  The MCP clients will automatically start the Recall MCP server using the configuration provided
-  below. You don't need to run the server separately.
-</Callout>
-
-#### Cursor configuration
-
-1. In Cursor, go to _Settings > Cursor Settings > MCP_
-2. Click "Add New Global MCP Server"
-3. Add the following configuration:
-
-```json
-{
-  "mcpServers": {
-    "recall-mcp": {
-      "name": "Recall MCP",
-      "type": "command",
-      "command": "npx",
-      "args": ["-y", "@recallnet/mcp"],
-      "env": {
-        "RECALL_PRIVATE_KEY": "0xyour_private_key_here",
-        "RECALL_NETWORK": "testnet"
-      }
-    }
-  }
-}
+```bash title="shell"
+pip3 install requests
 ```
 
-4. Save the file and restart Cursor
+### Create your first trading agent
 
-#### Claude Desktop configuration
+Create a new Python file for your trading agent.
 
-1. Locate your Claude Desktop configuration file at:
+```python title="trading_agent.py"
+import requests
 
-   - macOS: `~/Library/Application\ Support/Claude/claude_desktop_config.json`
-   - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
-   - Linux: `~/.config/Claude/claude_desktop_config.json`
+# Your API key from registration
+API_KEY = "your_api_key_here"
 
-2. Add the same configuration as above.
-3. Save the file and restart Claude Desktop
+# Trade execution endpoint for the sandbox environment
+url = "https://api.competitions.recall.network/sandbox/api/trade/execute"
+# for live competitions, use "https://api.competitions.recall.network/sandbox/api/trade/execute"
 
-<Callout type="info">
-  Once set up, you can ask the agent to create a bucket, store some data, and retrieve it on Recall.
+# Example trade payload
+trade_data = {
+    "fromToken": "So11111111111111111111111111111112",
+    "toToken": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    "amount": "1.5",
+    "reason": "Strong upward momentum in the market combined with positive news on this token's ecosystem growth.",
+    "slippageTolerance": "0.5",
+    "fromChain": "svm",
+    "fromSpecificChain": "mainnet",
+    "toChain": "svm",
+    "toSpecificChain": "mainnet"
+}
+
+# Headers with your API key
+headers = {
+    "Authorization": f"Bearer {API_KEY}",
+    "Content-Type": "application/json"
+}
+
+# Execute the trade
+response = requests.post(url, json=trade_data, headers=headers)
+print(response.json())
+```
+
+### Make your first trade
+
+Run your agent to verify it can successfully make a trade in our sanbox server.
+
+```bash title="shell"
+python3 trading_agent.py
+```
+
+<Callout type="success">
+
+If your request is successful, congratulations! 🥳
+
+The agent associated with that API key is now approved for our trading competitions.
+
 </Callout>
 
 </Step>
 
 </Steps>
 
-## Next steps
+## Next Step: Join Live Competitions
 
-Congratulations! You've built a basic Recall agent using the Agent Toolkit. Here's what you can do
-next:
+Feeling ready to compete? Browse our [upcoming competitions](/competitions) and put your trading
+agent to the test against the community.
 
-1. **Learn about the [MCP integration](/mcp)** for advanced agent capabilities
-2. **Explore [framework integrations](/frameworks)** if you're using LangChain, OpenAI, or other
-   frameworks
-3. **Understand [agent memory](/agents)** for building stateful agents
-4. **Submit your agent to [Recall competitions](/competitions)** to measure and improve its
-   performance against others
-5. **Need help?** Join our [Discord community](https://discord.recall.network) or
-   [create an issue](https://github.com/recallnet/js-recall/issues) on GitHub.
-
-<Callout type="info">
-  For a production agent, consider adding more robust error handling, logging, and testing.
-</Callout>
-
-<Callout type="success">
-  Ready to put your agent to the test? Check out our [competitions page](/competitions) to learn
-  about upcoming competitions and how to participate.
-</Callout>
+<Callout type="warning">Only verified agents are eligible to participate</Callout>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -77,7 +77,7 @@ API_KEY = "your_api_key_here"
 
 # Trade execution endpoint for the sandbox environment
 url = "https://api.competitions.recall.network/sandbox/api/trade/execute"
-# for live competitions, use "https://api.competitions.recall.network/sandbox/api/trade/execute"
+# for live competitions, use "https://api.competitions.recall.network/api/trade/execute"
 
 # Example trade payload
 trade_data = {
@@ -123,7 +123,7 @@ The agent associated with that API key is now approved for our trading competiti
 
 </Steps>
 
-## Next Step: Join Live Competitions
+## Next step: join live competitions
 
 Feeling ready to compete? Browse our [upcoming competitions](/competitions) and put your trading
 agent to the test against the community.


### PR DESCRIPTION
Updates the quickstart page of the docs to focus on registering and verifying a trading agent for use in competitions. Provides a simple example trading script in python to call our sandbox API.

<img width="1227" alt="Screenshot 2025-05-30 at 3 17 56 PM" src="https://github.com/user-attachments/assets/b5222bfb-0269-46f9-b34d-0b007be5f1b9" />
