### PR TITLE
chore: update "summer challenge" to "7 day trading challenge"

### DIFF
--- a/app/data/competitions.json
+++ b/app/data/competitions.json
@@ -17,12 +17,12 @@
       "url": "/competitions/eth-v-sol"
     },
     {
-      "id": "summer-challenge",
-      "name": "Summer Challenge",
+      "id": "7-day-trading-challenge",
+      "name": "7 Day Trading Challenge",
       "status": "OPEN",
-      "submissionDeadline": "June 30, 2025 at 11:59 PM EST",
-      "resultsDate": "July 9, 2025",
-      "url": "/competitions/summer-challenge"
+      "submissionDeadline": "July 7, 2025 at 11:59 PM EST",
+      "resultsDate": "July 16, 2025",
+      "url": "/competitions/7-day-trading-challenge"
     }
   ]
 }

--- a/app/layout.config.tsx
+++ b/app/layout.config.tsx
@@ -64,16 +64,16 @@ export const baseOptions: BaseLayoutProps = {
     },
   ],
   banner: {
-    id: "competition-summer-challenge",
+    id: "competition-7-day-trading-challenge",
     variant: "rainbow",
     children: (
       <>
         <Link
-          href="/competitions/summer-challenge"
+          href="/competitions/7-day-trading-challenge"
           className="text-fd-primary hover:text-fd-primary/80 inline-flex items-center font-bold transition-colors duration-200"
         >
           <PartyPopper size={16} className="mr-2" />
-          Join the Summer Challenge! Register by June 30
+          Join the 7 Day Trading Challenge! Register by July 7
           <LinkIcon size={16} className="ml-1" />
         </Link>
       </>

--- a/docs/competitions/7-day-trading-challenge.mdx
+++ b/docs/competitions/7-day-trading-challenge.mdx
@@ -1,18 +1,18 @@
 ---
-title: Summer Challenge (Open)
+title: 7 Day Trading Challenge (Open)
 description: AI trading competition on Recall
 ---
 
 import { getCompetition } from "@/lib/competitions";
 
-export const competition = getCompetition("summer-challenge");
+export const competition = getCompetition("7-day-trading-challenge");
 
-The Summer Challenge is an exciting AI trading competition that tests your agent's trading
+The 7 Day Trading Challenge is an exciting AI trading competition that tests your agent's trading
 capabilities in a competitive environment.
 
 <Callout type="info" title="Registration required">
 
-Summer Challenge is a selective competition. Your agent must be
+7 Day Trading Challenge is a selective competition. Your agent must be
 [registered](/competitions/guides/register) before joining an open competition.
 
 </Callout>
@@ -20,7 +20,7 @@ Summer Challenge is a selective competition. Your agent must be
 ## Overview
 
 - **Prize pool**: $10,000
-- **Duration**: 7 days (July 1 - July 8)
+- **Duration**: 7 days (July 8 - July 15)
 - **Focus**: AI-driven simulated crypto trading
 - **Submission deadline**: {competition.submissionDeadline}
 - **Results announcement**: {competition.resultsDate}
@@ -87,7 +87,7 @@ and once confirmed, you'll be added to the competition and can use the official 
 
 ## Technical requirements
 
-Your Summer Challenge competition submission must meet these requirements:
+Your 7 Day Trading Challenge competition submission must meet these requirements:
 
 - Make **at least 3 trades** per day
 - Handles market data inputs and trading decisions outputs—and executes trades

--- a/docs/competitions/index.mdx
+++ b/docs/competitions/index.mdx
@@ -10,10 +10,10 @@ import { CompetitionSchedule } from "@/components/competition-schedule";
 Competitions are at the heart of the Recall platform. They provide a way to test, prove, and
 showcase your agent's capabilities against others in the community.
 
-<Callout type="info" title="Summer Challenge competition is now open">
+<Callout type="info" title="7 Day Trading Challenge competition is now open">
 
-Register by June 30, 2025 for your chance to win
-$10,000—[learn more about Summer Challenge](/competitions/summer-challenge)!
+Register by July 7, 2025 for your chance to win
+$10,000—[learn more about 7 Day Trading Challenge](/competitions/7-day-trading-challenge)!
 
 </Callout>
 
@@ -28,7 +28,7 @@ $10,000—[learn more about Summer Challenge](/competitions/summer-challenge)!
 ## Competitions
 
 <Cards>
-  <Card title="Summer Challenge (Open)" href="/competitions/summer-challenge">
+  <Card title="7 Day Trading Challenge (Open)" href="/competitions/7-day-trading-challenge">
     A week long simulated crypto trading competition to test your agent's trading capabilities in a
     competitive environment.
   </Card>

--- a/docs/competitions/meta.json
+++ b/docs/competitions/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Competitions",
-  "pages": ["summer-challenge", "eth-v-sol", "alpha-wave", "registration"]
+  "pages": ["7-day-trading-challenge", "eth-v-sol", "alpha-wave", "registration"]
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,6 @@
 import { createMDX } from "fumadocs-mdx/next";
 import { NextConfig } from "next";
+import redirects from "./redirects.json";
 
 const withMDX = createMDX();
 
@@ -7,6 +8,13 @@ const config: NextConfig = {
   reactStrictMode: true,
   env: {
     OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+  },
+  async redirects() {
+    return redirects as Array<{
+      source: string;
+      destination: string;
+      permanent: boolean;
+    }>;
   },
 };
 

--- a/redirects.json
+++ b/redirects.json
@@ -1,0 +1,7 @@
+[
+  {
+    "source": "/competitions/summer-challenge",
+    "destination": "/competitions/7-day-trading-challenge",
+    "permanent": true
+  }
+]


### PR DESCRIPTION
- Change from "summer challenge" to "7 day trading challenge" for more standardized naming
  - Change references on other pages, metadata files
  - Create redirect (consistent `next.config.ts` with #64 to avoid merge conflict)
- Change dates from "July 1-8" to "July 8-15", including in top banner

<img width="1250" alt="Screenshot 2025-06-20 at 2 25 34 PM" src="https://github.com/user-attachments/assets/f6021d41-2638-485e-b2ee-2eed44105fbf" />
