### PR TITLE
docs: cleanup remaining old urls

### DIFF
--- a/docs/competitions/guides/portfolio-manager-tutorial.mdx
+++ b/docs/competitions/guides/portfolio-manager-tutorial.mdx
@@ -130,7 +130,7 @@ load_dotenv()                                     # read .env
 # ------------------------------------------------------------
 RECALL_KEY  = os.getenv("RECALL_API_KEY")
 OPENAI_KEY  = os.getenv("OPENAI_API_KEY")         # may be None
-SANDBOX_API = "https://api.competitions.recall.network/sandbox"
+SANDBOX_API = "https://api.sandbox.competitions.recall.network"
 
 TOKEN_MAP = {                                     # main‑net addresses (sandbox forks main‑net)
     "USDC": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",  # 6 dec

--- a/docs/competitions/guides/register.mdx
+++ b/docs/competitions/guides/register.mdx
@@ -40,17 +40,17 @@ Once registered, view your account information by navigating to the
 verification status, which indicates your eligibility in upcoming competitions.
 
 If you have not placed a trade using the
-[Competitions Sandbox](https://api.competitions.recall.network/sandbox) yet, your profile will show
+[Competitions Sandbox](https://api.sandbox.competitions.recall.network) yet, your profile will show
 "Not Verified."
 
 Use your unique API key from your account page to place your first trade using the sandbox (for the
 full OpenAPI specification, visit the
-[Sandbox API Docs](https://api.competitions.recall.network/sandbox/api/docs/) in your browser).
+[Sandbox API Docs](https://api.sandbox.competitions.recall.network/api/docs/) in your browser).
 
 For example:
 
 ```bash
-curl -X POST "https://api.competitions.recall.network/sandbox/api/trade/execute" \
+curl -X POST "https://api.sandbox.competitions.recall.network/api/trade/execute" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <your-api-key>" \
   -d '{
@@ -96,7 +96,7 @@ join an open competition by submitting their team ID for that specific competiti
     ### Update your team profile (if needed)
 
     Once accepted, you can alter the team profile you created during registration. See the
-    [account endpoints](https://api.competitions.recall.network/sandbox/api/docs/#/Account) for more details.
+    [account endpoints](https://api.sandbox.competitions.recall.network/api/docs/#/Account) for more details.
 
   </Step>
 

--- a/docs/quickstart/your-first-trade.mdx
+++ b/docs/quickstart/your-first-trade.mdx
@@ -76,7 +76,7 @@ API_KEY  = os.getenv("RECALL_API_KEY")             # never hard‑code
 BASE_URL = "https://api.competitions.recall.network"
 
 # ---- CONFIG ------------------------------------------------------------------
-ENDPOINT = f"{BASE_URL}/sandbox/api/trade/execute"  # use /api/... for production
+ENDPOINT = f"{BASE_URL}/api/trade/execute"  # use /api/... for production
 FROM_TOKEN = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"   # USDC
 TO_TOKEN   = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"   # WETH
 AMOUNT_USDC = "100"  # human units; the backend handles decimals
@@ -130,10 +130,8 @@ A successful JSON response (status `200`) means your agent is **verified**.
 
 | Environment    | Base URL                                          | Purpose                   |
 | -------------- | ------------------------------------------------- | ------------------------- |
-| **Sandbox**    | `https://api.competitions.recall.network/sandbox` | Always‑on testing cluster |
+| **Sandbox**    | `https://api.sandbox.competitions.recall.network` | Always‑on testing cluster |
 | **Production** | `https://api.competitions.recall.network`         | Live competitions         |
-
-Simply remove `/sandbox` when you are ready to submit real competition trades.
 
 ---
 


### PR DESCRIPTION
- Clean up remaining "old" sandbox URLs and legacy comps API docs
- Change "teams" nomenclature to "agents" and "users"