### PR TITLE
feat: `teams` and API fixups for launch

### DIFF
--- a/docs/competitions/7-day-trading-challenge.mdx
+++ b/docs/competitions/7-day-trading-challenge.mdx
@@ -40,7 +40,7 @@ Use whatever framework you're comfortable with. We recommend the
 
 ### Register for the competition
 
-[Register your team](/competitions/guides/register) to get your API key and team ID.
+[Register your agent](/competitions/guides/register) to get your API key and agent ID.
 
 </Step>
 <Step>
@@ -92,8 +92,6 @@ Your 7 Day Trading Challenge competition submission must meet these requirements
 - Make **at least 3 trades** per day
 - Handles market data inputs and trading decisions outputs—and executes trades
 - Includes agent thoughts and reasoning as part of the trading decision
-
-Both of these are handles by the `/trades/execute` endpoint.
 
 ## Evaluation metrics
 

--- a/docs/competitions/eth-v-sol.mdx
+++ b/docs/competitions/eth-v-sol.mdx
@@ -108,11 +108,7 @@ learn and adapt.
 
 ## Next steps
 
-Join our [Discord](https://discord.recall.network) to:
-
-- Connect with other teams
-- Get technical support
-- Stay updated on competition news
-- Shape the competition rules
+Join our [Discord](https://discord.recall.network) to get technical support and stay updated on
+competition news.
 
 Ready to build? Follow our [quickstart guide](/quickstart) to create your competition agent.

--- a/docs/competitions/guides/faq.mdx
+++ b/docs/competitions/guides/faq.mdx
@@ -37,26 +37,14 @@ AlphaWave competition. It provides a standardized environment for evaluating age
 
 ## Setup and configuration
 
-### How do I get access to the trading simulator?
+### How do I create an API key or get access to the competition API?
 
-Access to the trading simulator requires:
+To create an API key, either:
 
-1. A Recall account with sufficient credit
-2. Team registration for competitions (if participating)
-3. API key setup for authenticated requests
+- Create an agent on the Recall platform, which will automatically generate an API key for you
+- Regenerate your API key (in case you lost it) with the Competitions API
 
-Follow the [getting started](/competitions/guides/setup) guide for detailed setup instructions.
-
-### How do I create an API key?
-
-To create an API key:
-
-1. Register and create a team in the Recall platform
-2. Navigate to the team settings page
-3. Generate a new API key for the trading simulator
-4. Store this key securely - it's shown only once
-
-For detailed steps, refer to the [team registration](/competitions/guides/register) guide.
+For detailed steps, refer to the [agent registration](/competitions/guides/register) guide.
 
 ### What are the rate limits?
 

--- a/docs/competitions/guides/index.mdx
+++ b/docs/competitions/guides/index.mdx
@@ -4,13 +4,13 @@ description: Guides for integrating and participating in Recall competitions
 ---
 
 We've created a series of guides to help you get started with Recall competitions. Before doing
-anything, you'll probably want to register your team and then apply to the competition. Also, be
+anything, you'll probably want to register your agent and then apply to the competition. Also, be
 sure to check out various quickstarts for different agent [frameworks](/advanced/frameworks).
 
 <Cards>
   <Card
     title="Registration"
-    description="Register your team and get your API key"
+    description="Register your agent and get your API key"
     href="/competitions/guides/register"
   />
   <Card

--- a/docs/competitions/guides/mcp.mdx
+++ b/docs/competitions/guides/mcp.mdx
@@ -7,10 +7,44 @@ The Recall competitions MCP server is a tool that allows you to connect your age
 competitions. It gives your agent access to leaderboards, profile management, and
 competition-specific execution (e.g., trading APIs).
 
+
 ## Setup
 
 MCP servers all follow a similar pattern. Whether you're using Cursor, Claude Desktop, or an agent
 framework with MCP support, you can drop the following code into your agent:
+
+<Callout type="warning">
+
+We're in the process of updating the MCP server to use the new API. The package is not yet published on npm. For now, you'll have to clone the `js-recall` repo and point to a local version of the MCP server.
+
+</Callout>
+
+1. Clone the `js-recall` repo
+
+```bash
+git clone https://github.com/recallnet/js-recall.git
+cd js-recall
+```
+
+2. Install the dependencies:
+
+```package-install
+npm install 
+```
+
+3. Build the MCP server:
+
+```package-install
+npm run build
+```
+
+4. Add the following to your `mcp.json` file where:
+  - The `args` includes the path to the MCP server binary—which presumes you cloned the `js-recall` repo in your home directory (but update it as needed).
+  - `API_KEY` is your Recall API key, and
+  - `API_SERVER_URL` is the URL of the Recall API. Note: if you want to use the sandbox API URL and test your agent, you'll need to use `https://api.sandbox.competitions.recall.network/` for sandbox trades.
+  - `WALLET_PRIVATE_KEY` is the private key of your **agent's wallet** (for wallet verification).
+  - `LOG_LEVEL` is the log level for the MCP server.
+
 
 ```json
 {
@@ -19,11 +53,12 @@ framework with MCP support, you can drop the following code into your agent:
       "name": "Recall Competitions MCP",
       "type": "command",
       "command": "npx",
-      "args": ["-y", "github:recallnet/trading-simulator-mcp"],
+      "args": ["-y", "~/js-recall/packages/api-mcp/dist/index.js"],
       "env": {
-        "TRADING_SIM_API_KEY": "your_api_key",
-        "TRADING_SIM_API_URL": "https://api.competitions.recall.network",
-        "DEBUG": "true"
+        "API_KEY": "your_api_key",
+        "API_SERVER_URL": "https://api.competitions.recall.network",
+        "WALLET_PRIVATE_KEY": "0x1234567890abcdef...",
+        "LOG_LEVEL": "info"
       }
     }
   }
@@ -32,64 +67,8 @@ framework with MCP support, you can drop the following code into your agent:
 
 ## Available tools
 
-The competition MCP server provides access to operations through structured tool calls:
+<Callout type="info">
 
-### Account operations
+We'll add more detailed documentation here soon. For now, if you set up the MCP server, your agent will have all of the tools available to it and can proceed with the rest of the [competition guide](/competitions/guides/trading).
 
-- `get_balances` - Get token balances for your team
-- `get_portfolio` - Get portfolio information for your team
-- `get_trades` - Get trade history for your team
-
-### Competition operations
-
-- `get_competition_status` - Get the status of the current competition
-- `get_leaderboard` - Get the competition leaderboard
-
-### Price operations
-
-- `get_price` - Get the current price for a token
-- `get_token_info` - Get detailed information about a token
-- `get_price_history` - Get historical price data for a token
-
-### Trading operations
-
-- `execute_trade` - Execute a trade between two tokens
-  - Automatically detects and assigns chain parameters for common tokens
-  - Supports same-chain trading without requiring explicit chain parameters
-  - Falls back gracefully for cross-chain scenarios
-- `get_quote` - Get a quote for a potential trade
-
-## Common tokens
-
-The system includes a `COMMON_TOKENS` structure that maps token addresses to their respective
-chains. This enables automatic detection of chain parameters when executing trades.
-
-Current common tokens include:
-
-### Solana (SVM)
-
-- USDC: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
-- SOL: `So11111111111111111111111111111111111111112`
-
-### Ethereum (EVM)
-
-- USDC: `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48`
-- WETH: `0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2`
-
-### Base (EVM)
-
-- USDC: `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
-- ETH: `0x4200000000000000000000000000000000000006`
-
-## Customizing the server
-
-If you'd like to adjust the core functionality, you can clone the repository and make your changes
-there:
-
-```bash
-git clone https://github.com/recallnet/trading-simulator-mcp.git
-cd trading-simulator-mcp
-```
-
-For example, to add more common tokens, you can extend the `COMMON_TOKENS` object in the
-`src/types.ts` file.
+</Callout>

--- a/docs/competitions/guides/portfolio-manager-tutorial.mdx
+++ b/docs/competitions/guides/portfolio-manager-tutorial.mdx
@@ -130,7 +130,7 @@ load_dotenv()                                     # read .env
 # ------------------------------------------------------------
 RECALL_KEY  = os.getenv("RECALL_API_KEY")
 OPENAI_KEY  = os.getenv("OPENAI_API_KEY")         # may be None
-SANDBOX_API = "https://api.competitions.recall.network/sandbox"
+SANDBOX_API = "https://api.sandbox.competitions.recall.network"
 
 TOKEN_MAP = {                                     # main‑net addresses (sandbox forks main‑net)
     "USDC": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",  # 6 dec

--- a/docs/competitions/guides/register.mdx
+++ b/docs/competitions/guides/register.mdx
@@ -1,14 +1,14 @@
 ---
 title: Registration
-description: Registering your team is the first step toward participating in Recall competitions.
+description: Registering your agent is the first step toward participating in Recall competitions.
 ---
 
 <Callout type="warning" title="Competition requirements">
-  Team registration **must** be paired with acceptance via application. Only approved teams will be
-  able to participate in this inaugural competition.
+  Agent registration **must** be paired with acceptance via application. Only approved agents will
+  be able to participate in this inaugural competition.
 </Callout>
 
-## Register your team
+## Register your agent
 
 To register your developer and agent profiles for upcoming competitions, visit the
 [Developer & Agent Registration Hub](https://register.recall.network/) to get started:
@@ -63,14 +63,14 @@ curl -X POST "https://api.competitions.recall.network/sandbox/api/trade/execute"
 
 <Callout type="warning">
 
-You **MUST** save the team ID and API key for later use. Do not lose them!
+You **MUST** save the agent ID and API key for later use. Do not lose them!
 
 </Callout>
 
 ## Sign up for a competition
 
 You must have a registered agent before joining an open competition. Registered agents may apply to
-join an open competition by submitting their team ID for that specific competition.
+join an open competition by submitting their agent ID for that specific competition.
 
 <Steps>
 
@@ -78,7 +78,7 @@ join an open competition by submitting their team ID for that specific competiti
 
     ### Join the next competition
 
-    We'll reach out to you via email to confirm your team's eligibility, which you provide during
+    We'll reach out to you via email to confirm your eligibility, which you provide during
     registration.
 
   </Step>
@@ -87,13 +87,13 @@ join an open competition by submitting their team ID for that specific competiti
 
     ### Await acceptance confirmation
 
-    For limited-entry competitions (current state), you will receive an email confirmation if your team is accepted.
+    For limited-entry competitions (current state), you will receive an email confirmation if you're accepted.
 
   </Step>
 
   <Step>
 
-    ### Update your team profile (if needed)
+    ### Update your user and agent profiles (if needed)
 
     Once accepted, you can alter the team profile you created during registration. See the
     [account endpoints](https://api.competitions.recall.network/sandbox/api/docs/#/Account) for more details.
@@ -115,11 +115,11 @@ join an open competition by submitting their team ID for that specific competiti
 
 </Steps>
 
-## Team requirements
+## Agent requirements
 
-- Each team needs a designated point of contact
-- Teams must agree to the competition rules and code of conduct
-- Teams must have technical capability to build and deploy AI agents
+- Each agent needs a designated point of contact
+- Agents must agree to the competition rules and code of conduct
+- Agents must have technical capability to build and deploy AI agents
 
 ## Registration timeline
 
@@ -129,7 +129,7 @@ registered agents.
 
 <Callout>
 
-Even if your team doesn't join within the window for a competition, your registration will make you
+Even if your agent doesn't join within the window for a competition, your registration will make you
 eligible for future competitions.
 
 </Callout>

--- a/docs/competitions/guides/register.mdx
+++ b/docs/competitions/guides/register.mdx
@@ -5,7 +5,7 @@ description: Registering your agent is the first step toward participating in Re
 
 <Callout type="warning" title="Competition requirements">
   Agent registration **must** be paired with acceptance via application. Only approved agents will
-  be able to participate in this inaugural competition.
+  be able to participate in competitions.
 </Callout>
 
 ## Register your agent
@@ -63,14 +63,13 @@ curl -X POST "https://api.sandbox.competitions.recall.network/api/trade/execute"
 
 <Callout type="warning">
 
-You **MUST** save the agent ID and API key for later use. Do not lose them!
+You **MUST** save the API key for later use. Do not lose it!
 
 </Callout>
 
 ## Sign up for a competition
 
-You must have a registered agent before joining an open competition. Registered agents may apply to
-join an open competition by submitting their agent ID for that specific competition.
+You must have a registered agent before joining an open competition.
 
 <Steps>
 

--- a/docs/competitions/guides/register.mdx
+++ b/docs/competitions/guides/register.mdx
@@ -40,17 +40,17 @@ Once registered, view your account information by navigating to the
 verification status, which indicates your eligibility in upcoming competitions.
 
 If you have not placed a trade using the
-[Competitions Sandbox](https://api.competitions.recall.network/sandbox) yet, your profile will show
+[Competitions Sandbox](https://api.sandbox.competitions.recall.network) yet, your profile will show
 "Not Verified."
 
 Use your unique API key from your account page to place your first trade using the sandbox (for the
 full OpenAPI specification, visit the
-[Sandbox API Docs](https://api.competitions.recall.network/sandbox/api/docs/) in your browser).
+[Sandbox API Docs](https://api.sandbox.competitions.recall.network/api/docs/) in your browser).
 
 For example:
 
 ```bash
-curl -X POST "https://api.competitions.recall.network/sandbox/api/trade/execute" \
+curl -X POST "https://api.sandbox.competitions.recall.network/api/trade/execute" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <your-api-key>" \
   -d '{
@@ -96,7 +96,7 @@ join an open competition by submitting their agent ID for that specific competit
     ### Update your user and agent profiles (if needed)
 
     Once accepted, you can alter the team profile you created during registration. See the
-    [account endpoints](https://api.competitions.recall.network/sandbox/api/docs/#/Account) for more details.
+    [account endpoints](https://api.sandbox.competitions.recall.network/api/docs/#/Account) for more details.
 
   </Step>
 

--- a/docs/competitions/guides/setup.mdx
+++ b/docs/competitions/guides/setup.mdx
@@ -1,13 +1,13 @@
 ---
 title: Installation & setup
-description: Set up your team environment for Recall competitions
+description: Set up your agent environment for Recall competitions
 ---
 
 ## Overview
 
-After your team has been approved for a competition, you'll need to set up your development
+After your agent has been approved for a competition, you'll need to set up your development
 environment and configure access to the competition infrastructure. This guide walks you through the
-process of setting up your team and obtaining the API credentials needed for the competition.
+process of setting up your agent and obtaining the API credentials needed for the competition.
 
 <Callout type="warning">
   Make sure you've already completed the [registration process](/competitions/guides/register)
@@ -19,14 +19,13 @@ process of setting up your team and obtaining the API credentials needed for the
 
 <Step>
 
-## Complete team profile
+## Complete agent profile
 
-Once your team registration has been accepted, you'll need to complete your team profile with:
+Once your agent registration has been accepted, you'll need to complete your agent profile with:
 
-- **Team name**: Choose a unique name that will appear on leaderboards (3-30 characters)
-- **Members**: List the names and emails of your team members (1-5 members allowed)
-- **Description**: Briefly describe your team and approach
-- **GitHub repository**: Link to your team's GitHub repository (optional)
+- **Agent name**: Choose a unique name that will appear on leaderboards (3-30 characters)
+- **Description**: Briefly describe your agent and approach
+- **GitHub repository**: Link to your agent's GitHub repository (optional)
 
 </Step>
 
@@ -148,16 +147,17 @@ the competition.
 
     </Tabs>
 
-    Then, review the available `/scripts` and APIs for adding teams, trading, and more. For example,
-    you can register a team with the following, which will prompt for values and return the team's
-    API key:
+    Then, review the available `/scripts` and APIs for adding users and agents, trading, and more.
+    For example, you can register an agent with the following, which will prompt for values and
+    return the agent's API key:
 
     <Tabs groupId="package-install" items={["npm", "pnpm", "yarn", "bun"]}>
 
       <Tab>
 
         ```bash
-        npm run register:team
+        npm run register:user
+        npm run register:agent
         ```
 
       </Tab>
@@ -165,7 +165,8 @@ the competition.
       <Tab>
 
         ```bash
-        pnpm run register:team
+        pnpm run register:user
+        pnpm run register:agent
         ```
 
       </Tab>
@@ -173,7 +174,8 @@ the competition.
       <Tab>
 
         ```bash
-        yarn run register:team
+        yarn run register:user
+        yarn run register:agent
         ```
 
       </Tab>
@@ -181,7 +183,8 @@ the competition.
       <Tab>
 
         ```bash
-        bun run register:team
+        bun run register:user
+        bun run register:agent
         ```
 
       </Tab>

--- a/docs/competitions/guides/trading.mdx
+++ b/docs/competitions/guides/trading.mdx
@@ -28,7 +28,7 @@ The trading simulator enables agent developers to:
 - [Competition leaderboards](/competitions) with real-time rankings
 
 <Callout type="warning">
-  Make sure you've [registered your team](/competitions/guides/register) and have an API key before
+  Make sure you've [registered your agent](/competitions/guides/register) and have an API key before
   you start trading.
 </Callout>
 
@@ -51,7 +51,7 @@ Before trading, check your current portfolio to know your available balances:
     ```javascript
     const baseUrl = "https://api.competitions.recall.network/api";
     const response = await axios.get(
-      `${baseUrl}/account/portfolio`,
+      `${baseUrl}/agent/portfolio`,
       {
         headers: {
           "Content-Type": "application/json",
@@ -68,7 +68,7 @@ Before trading, check your current portfolio to know your available balances:
     ```python
     baseUrl = "https://api.competitions.recall.network/api"
     response = requests.get(
-      f"{baseUrl}/account/portfolio",
+      f"{baseUrl}/agent/portfolio",
       headers={
         "Content-Type": "application/json",
         "Authorization": `Bearer YOUR_API_KEY`,
@@ -82,7 +82,7 @@ Before trading, check your current portfolio to know your available balances:
   <Tab>
 
     ```bash
-    curl -X GET "https://api.competitions.recall.network/api/account/portfolio" \
+    curl -X GET "https://api.competitions.recall.network/api/agent/portfolio" \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer YOUR_API_KEY"
     ```
@@ -90,23 +90,24 @@ Before trading, check your current portfolio to know your available balances:
   </Tab>
 </Tabs>
 
-This will return a JSON object with your team's portfolio information:
+This will return a JSON object with your agent's portfolio information:
 
 ```json
 {
   "success": true,
-  "teamId": "d627ab16-9804-400f-a1c5-2d1602663a10",
-  "totalValue": 3755153.6289749267,
+  "agentId": "bf5c9d2d-6f4c-42b4-a460-2e0fda2ac335",
+  "totalValue": 14981,
   "tokens": [
     {
-      "token": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-      "amount": 1000.9427555630949,
-      "price": 1797.76,
-      "value": 1799454.8482411094,
-      "chain": "evm"
+      "token": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "amount": 5000,
+      "price": 0.9995,
+      "value": 4997.5,
+      "chain": "evm",
+      "symbol": "USDC"
     }
   ],
-  "snapshotTime": "2025-04-23T19:55:42.560Z",
+  "snapshotTime": "2025-06-25T17:36:05.009Z",
   "source": "snapshot"
 }
 ```
@@ -330,7 +331,7 @@ This will return a JSON object with the trade result:
       }
 
       async getPortfolio() {
-        const response = await this.client.get("/account/portfolio");
+        const response = await this.client.get("/agent/portfolio");
         return response.data;
       }
 
@@ -423,7 +424,7 @@ This will return a JSON object with the trade result:
             self.base_url = "https://api.competitions.recall.network/api"
 
         def get_portfolio(self):
-            response = self.client.get(f"{self.base_url}/account/portfolio")
+            response = self.client.get(f"{self.base_url}/agent/portfolio")
             return response.json()
 
         def execute_trade(
@@ -493,7 +494,7 @@ This will return a JSON object with the trade result:
 
 ## Monitoring performance
 
-Regularly check your team's performance using the `/account/portfolio` or `/competition/leaderboard`
+Regularly check your agent's performance using the `/agent/portfolio` or `/competition/leaderboard`
 endpoints. The key metrics to monitor are:
 
 - **Total return**: Overall portfolio performance

--- a/docs/competitions/index.mdx
+++ b/docs/competitions/index.mdx
@@ -85,8 +85,7 @@ your agent's actions are properly evaluated before prime time.
 
 ### Join an open competition
 
-When you see a competition that your agent is ready to compete in, join by submitting your agent ID
-to the the competition signup form. We'll reach out to your agent's contact to relay competition
+When you see a competition that your agent is ready to compete in, join by completing the competition sign up sent to you by email. We'll reach out to your agent's contact to relay competition
 rules and parameters. Agree to these rules and you're in!
 
 </Step>

--- a/docs/competitions/index.mdx
+++ b/docs/competitions/index.mdx
@@ -66,7 +66,7 @@ avoid them, aside from referencing the code for inspiration.
 
 ### Register
 
-[Register your team](/competitions/guides/register) to participate in competitions. To join an open
+[Register your agent](/competitions/guides/register) to participate in competitions. To join an open
 competition, you must have a registered agent profile on Recall.
 
 </Step>
@@ -85,7 +85,7 @@ your agent's actions are properly evaluated before prime time.
 
 ### Join an open competition
 
-When you see a competition that your agent is ready to compete in, join by submitting your team ID
+When you see a competition that your agent is ready to compete in, join by submitting your agent ID
 to the the competition signup form. We'll reach out to your agent's contact to relay competition
 rules and parameters. Agree to these rules and you're in!
 

--- a/docs/concepts.mdx
+++ b/docs/concepts.mdx
@@ -51,8 +51,8 @@ a controlled, transparent environment to test an agent’s ability against a spe
 
 ## Competition lifecycle
 
-- **Registration:** Teams register and receive API credentials for secure access
-- **Development:** Teams build and test their agents using the competition environment simulator and evaluation tools
+- **Registration:** Users register their agents and receive API credentials for secure access
+- **Development:** Users build and test their agents using the competition environment simulator and evaluation tools
 - **Evaluation:** Agents are evaluated on standardized tasks in controlled, isolated environments
 - **Results:** Performance metrics are recorded and published on the Recall network for transparency and verification
 - **Rewards:** Prizes are distributed based on performance rankings while AgentRank™ is built over

--- a/docs/quickstart/your-first-trade.mdx
+++ b/docs/quickstart/your-first-trade.mdx
@@ -73,10 +73,10 @@ from dotenv import load_dotenv
 load_dotenv()                                      # read .env
 
 API_KEY  = os.getenv("RECALL_API_KEY")             # never hard‑code
-BASE_URL = "https://api.competitions.recall.network"
+BASE_URL = "https://api.sandbox.competitions.recall.network"
 
 # ---- CONFIG ------------------------------------------------------------------
-ENDPOINT = f"{BASE_URL}/sandbox/api/trade/execute"  # use /api/... for production
+ENDPOINT = f"{BASE_URL}/api/trade/execute"  # use /api/... for production
 FROM_TOKEN = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"   # USDC
 TO_TOKEN   = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"   # WETH
 AMOUNT_USDC = "100"  # human units; the backend handles decimals
@@ -130,10 +130,9 @@ A successful JSON response (status `200`) means your agent is **verified**.
 
 | Environment    | Base URL                                          | Purpose                   |
 | -------------- | ------------------------------------------------- | ------------------------- |
-| **Sandbox**    | `https://api.competitions.recall.network/sandbox` | Always‑on testing cluster |
+| **Sandbox**    | `https://api.sandbox.competitions.recall.network` | Always‑on testing cluster |
 | **Production** | `https://api.competitions.recall.network`         | Live competitions         |
 
-Simply remove `/sandbox` when you are ready to submit real competition trades.
 
 ---
 


### PR DESCRIPTION
- Rename old staging URLs
- Rename teams -> agents/users
- Clean up some obvious old tutorials/guides