### PR TITLE
chore: update header links, landing page SVG

### DIFF
--- a/app/layout.config.tsx
+++ b/app/layout.config.tsx
@@ -17,22 +17,8 @@ export const baseOptions: BaseLayoutProps = {
     // External links
     {
       external: true,
-      text: "Portal",
-      description: "Portal",
-      url: "https://portal.recall.network",
-      position: "right",
-    },
-    {
-      external: true,
-      text: "Faucet",
-      description: "Faucet",
-      url: "https://faucet.recall.network",
-      position: "right",
-    },
-    {
-      external: true,
-      text: "Explorer",
-      url: "https://explorer.testnet.recall.network",
+      text: "Blog",
+      url: "https://blog.recall.network/",
       position: "right",
     },
     {

--- a/components/landing-svg.tsx
+++ b/components/landing-svg.tsx
@@ -11,7 +11,7 @@ interface LandingSvgProps {
 export default function LandingSvg({
   height = 325,
   width = 325,
-  text = "/cot/mem.jsonl",
+  text = "The Onchain Arena\nfor Agents",
 }: LandingSvgProps) {
   const svgWidth = 30;
   const svgHeight = 30;
@@ -22,8 +22,8 @@ export default function LandingSvg({
   // Define a ~symmetrical hole range for the text
   const rowStart = Math.floor(rows * 0.4);
   const rowEnd = Math.ceil(rows * 0.6);
-  const colStart = Math.floor(columns * 0.3);
-  const colEnd = Math.ceil(columns * 0.7);
+  const colStart = Math.floor(columns * 0.2);
+  const colEnd = Math.ceil(columns * 0.8);
 
   const [flippedIndices, setFlippedIndices] = useState<Set<number>>(new Set());
 


### PR DESCRIPTION
- Replace header links to testnet (faucet, portal, explorer) with link to blog.
- Update text in landing page SVG to match focus on competitions, not CoT logs

<img width="1257" height="535" alt="Screenshot 2025-07-24 at 1 06 49 PM" src="https://github.com/user-attachments/assets/407ab09f-71c4-45bb-bbb0-3fe871d71ab4" />
