### PR TITLE
feat: add Recall Predict page, banner, and cross-links

### DIFF
--- a/app/layout.config.tsx
+++ b/app/layout.config.tsx
@@ -49,22 +49,23 @@ export const baseOptions: BaseLayoutProps = {
       url: "https://github.com/recallnet",
     },
   ],
-  // banner: {
-  //   id: "competition-7-day-trading-challenge",
-  //   variant: "rainbow",
-  //   children: (
-  //     <>
-  //       <Link
-  //         href="/competitions/7-day-trading-challenge"
-  //         className="text-fd-primary hover:text-fd-primary/80 inline-flex items-center font-bold transition-colors duration-200"
-  //       >
-  //         <PartyPopper size={16} className="mr-2" />
-  //         Join the 7 Day Trading Challenge! Register by July 7
-  //         <LinkIcon size={16} className="ml-1" />
-  //       </Link>
-  //     </>
-  //   ),
-  // },
+  banner: {
+    id: "recall-predict",
+    variant: "rainbow",
+    children: (
+      <>
+        <Link
+          href="https://predict.recall.network/"
+          className="text-fd-primary hover:text-fd-primary/80 inline-flex items-center font-bold transition-colors duration-200"
+        >
+          <PartyPopper size={16} className="mr-2" />
+          Recall Predict is live! Help us create humanity&apos;s first ungameable benchmark for
+          GPT-5.
+          <LinkIcon size={16} className="ml-1" />
+        </Link>
+      </>
+    ),
+  },
   nav: {
     title: (
       <>

--- a/components/landing-page.tsx
+++ b/components/landing-page.tsx
@@ -22,9 +22,9 @@ const features = [
   },
   {
     icon: <Network className="text-blue h-6 w-6" />,
-    title: "MCP integration",
-    href: "/competitions/guides/mcp",
-    description: "Use the Model Context Protocol with Recall",
+    title: "Predict the best models",
+    href: "/predict",
+    description: "Contribute to the world's first ungamable benchmark",
   },
   {
     icon: <Lightbulb className="text-blue h-6 w-6" />,

--- a/docs/meta.json
+++ b/docs/meta.json
@@ -7,6 +7,8 @@
     "quickstart/your-first-trade",
     "concepts",
     "partners",
+    "---Predict---",
+    "predict",
     "---Compete & earn---",
     "competitions",
     "competitions/guides",

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -25,8 +25,8 @@ Recall is the proving ground for autonomous agents. It’s where builders test, 
   <Card title="Join open competitions" href="/competitions">
     Test your agent across high-signal challenges
   </Card>
-  <Card title="Competitions MCP integration" href="/competitions/guides/mcp">
-    Supercharge your agent for competitions
+  <Card title="Predict the strongest models" href="/predict">
+    Contribute to the world's first ungamable benchmark
   </Card>
   <Card title="Quickstart" href="/quickstart">
     Execute your first AI agent trade in minutes

--- a/docs/predict.mdx
+++ b/docs/predict.mdx
@@ -1,0 +1,59 @@
+---
+title: Recall Predict
+description: Help create the world's first ungameable AI benchmark powered by community predictions
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+[Recall Predict](https://predict.recall.network) transforms AI model evaluation from outdated
+benchmarking into engaging community predictions. Instead of relying on traditional tests that can
+be gamed or become outdated, we're building a dynamic, community-driven evaluation system where
+users make predictions about GPT-5's skills compared to other leading models.
+
+## Static benchmarks can't keep up
+
+Traditional AI benchmarks suffer from several critical flaws:
+
+- **Gaming vulnerability**: Models can be specifically trained to perform well on known benchmarks
+- **Static evaluation**: Fixed test sets become outdated as AI skills evolve
+- **Limited scope**: Traditional benchmarks often miss emerging skills or real-world use cases
+
+## You are humanity's only hope
+
+Recall Predict solves these problems through crowdsourced predictions and evaluations across a wide
+range of skills.
+
+### Make predictions
+
+The core of Recall Predict is making comparative predictions about AI model skills. For each skill
+category, you'll see pairs of models and predict whether GPT-5 will be stronger or weaker than the
+comparison model.
+
+<Callout type="info">
+  [Make predictions](https://predict.recall.network/) about GPT-5's expected performance against
+  other models across various skills.
+</Callout>
+
+### Submit new evaluation prompts for a specific skill
+
+High-quality evaluation prompts are crucial for meaningful comparisons. When you submit prompts for
+a skill category, you're helping create the actual test cases that will be used to compare GPT-5
+against other models.
+
+<Callout type="info">
+  [Submit new evaluation prompts](https://predict.recall.network/evaluations) that help test
+  specific skills more effectively.
+</Callout>
+
+### Suggest new skills to test
+
+The AI landscape evolves rapidly, and new skills emerge constantly. By suggesting new skill
+categories, you help ensure our benchmark captures the full spectrum of AI advancement.
+
+New skill suggestions that gain community support are integrated into the platform, making the
+benchmark more comprehensive and valuable for the entire AI ecosystem.
+
+<Callout type="info">
+  [Propose entirely new skill categories](https://predict.recall.network/skills/submit) for
+  benchmarking to help capture the full spectrum of AI advancement.
+</Callout>


### PR DESCRIPTION
- Create a page for Recall Predict.
- Make docs banner CTA related to Recall Predict.
- Update a couple landing pages with info and links to the Predict page.

<img width="1257" height="1137" alt="Screenshot 2025-08-01 at 2 04 10 PM" src="https://github.com/user-attachments/assets/9c2a5dae-0375-4c83-a63f-96faabd0e200" />
