### PR TITLE
Fix: responsive placement of Copy Page button on mobile (#101)

### DIFF
--- a/components/md-copy/actions.tsx
+++ b/components/md-copy/actions.tsx
@@ -45,7 +45,7 @@ export function MarkdownActions({ currentPath }: MarkdownActionsProps) {
   };
 
   return (
-    <div className="flex">
+    <div className="hidden sm:flex">
       <button
         onClick={handleCopy}
         className={cn(

--- a/components/theme/page.tsx
+++ b/components/theme/page.tsx
@@ -174,7 +174,7 @@ export function DocsPage({
             props.article?.className
           )}
         >
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 sm:gap-0">
             {replaceOrDefault(props.breadcrumb, <Breadcrumb {...props.breadcrumb} />)}
             {props.currentPath && <MarkdownActions currentPath={props.currentPath} />}
           </div>


### PR DESCRIPTION
### What this does
- Hides the Copy Page button on mobile devices (< 640px)
- Uses Tailwind's `hidden sm:flex` to conditionally render the button
- Ensures breadcrumb/title takes full width on small screens

### Why
- Fixes UI issue where the button clutters or overlaps on mobile
- Improves readability and user experience

Fixes #101